### PR TITLE
WIP: Allow testing packages from any registry

### DIFF
--- a/deps/Registries.toml
+++ b/deps/Registries.toml
@@ -1,0 +1,41 @@
+["General"]
+url = "https://github.com/JuliaRegistries/General.git"
+skip = [
+    "AbstractAlgebra", # Hangs forever
+    "ChangePrecision", # Hangs forever
+    "Chunks", # Hangs forever
+    "DiscretePredictors", # Hangs forever
+    "DotOverloading",
+    "DynamicalBilliards", # Hangs forever
+    "Electron",
+    "Embeddings",
+    "GeoStatsDevTools",
+    "HCubature",
+    "IndexableBitVectors",
+    "LatinHypercubeSampling", # Hangs forever
+    "LazyCall", # deleted, hangs
+    "LazyContext",
+    "LinearLeastSquares", # Hangs forever
+    "MeshCatMechanisms",
+    "NumberedLines",
+    "OrthogonalPolynomials", # Hangs forever
+    "Parts", # Hangs forever
+    "Rectangle", # Hangs forever
+    "RecurUnroll", # deleted, hangs
+    "RequirementVersions",
+    "SLEEF", # Hangs forever
+    "SequentialMonteCarlo",
+    "SessionHacker",
+    "TypedBools", # deleted, hangs
+    "ValuedTuples",
+    "ZippedArrays", # Hangs forever
+]
+okay = [
+    "BinDeps", # Not really ok, but packages may list it just as a fallback
+    "Compat",
+    "Homebrew",
+    "InteractiveUtils", # We rely on LD_LIBRARY_PATH working for the moment
+    "LinearAlgebra", # Takes too long
+    "NamedTuples", # As requested by quinnj
+    "WinRPM",
+]


### PR DESCRIPTION
This extends `get_registry` to allow registries other than General. It also fixes the code path taken when a registry has already been cloned, which previously just errored.

I'm marking as WIP because there might be other things that need to be adjusted for it to work well with other registries. As it stands this just makes it possible. In preliminary testing it seems like it sort of works... but not like production quality working.