### PR TITLE
Differentiate between versions (version, file, sha) and builds (name, url)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 logs/
 deps/*
 !deps/*.toml
+bin/test.db

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 logs/
 deps/*
-!deps/Registries.toml
-!deps/Versions.toml
+!deps/*.toml

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,9 @@ julia:
   - 1.3
 
 env:
-  - JULIA_VERSION=1.3.0-rc5
-  - JULIA_VERSION=nightly
-  - JULIA_VERSION=master
+  - JULIA_VERSION=v1.3.0-rc5  # entry straight in Versions.toml
+  - JULIA_VERSION=latest      # entry from Builds.toml
+  - JULIA_VERSION=master      # directly from Git
 
 branches:
   only:

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -28,6 +28,12 @@ git-tree-sha1 = "5b08ed6036d9d3f0ee6369410b830f8873d4024c"
 uuid = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
 version = "0.5.8"
 
+[[CSTParser]]
+deps = ["Tokenize"]
+git-tree-sha1 = "99dda94f5af21a4565dc2b97edf6a95485f116c3"
+uuid = "00ebfdb7-1f24-5e51-bd34-a7502290713f"
+version = "1.0.0"
+
 [[CodecZlib]]
 deps = ["BinaryProvider", "Libdl", "TranscodingStreams"]
 git-tree-sha1 = "05916673a2627dd91b4969ff8ba6941bc85a960e"
@@ -42,9 +48,9 @@ version = "0.8.0"
 
 [[Compat]]
 deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
-git-tree-sha1 = "ed2c4abadf84c53d9e58510b5fc48912c2336fbb"
+git-tree-sha1 = "0caaa696071d6e7872ddf30e58ed6ec0b49954c4"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "2.2.0"
+version = "3.0.0"
 
 [[DataAPI]]
 git-tree-sha1 = "674b67f344687a88310213ddfa8a2b3c76cc4252"
@@ -53,9 +59,9 @@ version = "1.1.0"
 
 [[DataStructures]]
 deps = ["InteractiveUtils", "OrderedCollections"]
-git-tree-sha1 = "f94423c68f2e47db0d6f626a26d4872266e0ec3d"
+git-tree-sha1 = "1fe8fad5fc84686dcbc674aa255bc867a64f8132"
 uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-version = "0.17.2"
+version = "0.17.5"
 
 [[DataValueInterfaces]]
 git-tree-sha1 = "bfc1187b79289637fa0ef6d4436ebdfe6905cbd6"
@@ -96,10 +102,10 @@ uuid = "8f6bce27-0656-5410-875b-07a5572985df"
 version = "0.1.5"
 
 [[GitHub]]
-deps = ["Base64", "Compat", "Dates", "HTTP", "JSON", "MbedTLS", "Sockets", "Test"]
-git-tree-sha1 = "0224f2efcf87d783d64861e4a9ee08299164a569"
+deps = ["Base64", "Dates", "HTTP", "JSON", "MbedTLS", "Sockets"]
+git-tree-sha1 = "477818ab174a14d4730b3d15ac8719dbc98555d2"
 uuid = "bc5e4493-9b4d-5f90-b8aa-2b2bcaad7a26"
-version = "5.1.1"
+version = "5.1.3"
 
 [[HTTP]]
 deps = ["Base64", "Dates", "IniFile", "MbedTLS", "Sockets"]
@@ -130,9 +136,9 @@ version = "1.0.0"
 
 [[JLD2]]
 deps = ["CodecZlib", "DataStructures", "FileIO", "Mmap", "Pkg", "Printf", "UUIDs"]
-git-tree-sha1 = "d0068cf2c639ee6bf458f8db6252e7d54ebc5cd3"
+git-tree-sha1 = "4fc5779f938c5754c6361c131704ab3d910377f6"
 uuid = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
-version = "0.1.5"
+version = "0.1.7"
 
 [[JSON]]
 deps = ["Dates", "Mmap", "Parsers", "Unicode"]
@@ -166,10 +172,10 @@ uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
 
 [[MacroTools]]
-deps = ["Compat", "DataStructures", "Test"]
-git-tree-sha1 = "82921f0e3bde6aebb8e524efc20f4042373c0c06"
+deps = ["CSTParser", "Compat", "DataStructures", "Test", "Tokenize"]
+git-tree-sha1 = "d6e9dedb8c92c3465575442da456aec15a89ff76"
 uuid = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
-version = "0.5.2"
+version = "0.5.1"
 
 [[Markdown]]
 deps = ["Base64"]
@@ -308,6 +314,11 @@ deps = ["Dates", "Test"]
 git-tree-sha1 = "43defcaf72b89b047f11b778cd83b71ac3e418b0"
 uuid = "37f0c46e-897f-50ef-b453-b26c3eed3d6c"
 version = "0.2.0"
+
+[[Tokenize]]
+git-tree-sha1 = "dfcdbbfb2d0370716c815cbd6f8a364efb6f42cf"
+uuid = "0796e94c-ce3b-5d07-9a54-7f471281c624"
+version = "0.5.6"
 
 [[TranscodingStreams]]
 deps = ["Random", "Test"]

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -34,6 +34,12 @@ git-tree-sha1 = "99dda94f5af21a4565dc2b97edf6a95485f116c3"
 uuid = "00ebfdb7-1f24-5e51-bd34-a7502290713f"
 version = "1.0.0"
 
+[[CategoricalArrays]]
+deps = ["Compat", "DataAPI", "Future", "JSON", "Missings", "Printf", "Reexport", "Unicode"]
+git-tree-sha1 = "45101c4d0df3946acb6e9bfcfd3a8c32abbd421b"
+uuid = "324d7699-5711-5eae-9e2f-1d82baa6b597"
+version = "0.7.1"
+
 [[CodecZlib]]
 deps = ["BinaryProvider", "Libdl", "TranscodingStreams"]
 git-tree-sha1 = "05916673a2627dd91b4969ff8ba6941bc85a960e"
@@ -56,6 +62,12 @@ version = "3.0.0"
 git-tree-sha1 = "674b67f344687a88310213ddfa8a2b3c76cc4252"
 uuid = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
 version = "1.1.0"
+
+[[DataFrames]]
+deps = ["CategoricalArrays", "Compat", "IteratorInterfaceExtensions", "Missings", "PooledArrays", "Printf", "REPL", "Reexport", "SortingAlgorithms", "Statistics", "StatsBase", "TableTraits", "Tables", "Unicode"]
+git-tree-sha1 = "7c0f86a01be0f77cc7f3f9096ed875f1217487e1"
+uuid = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+version = "0.18.4"
 
 [[DataStructures]]
 deps = ["InteractiveUtils", "OrderedCollections"]
@@ -94,6 +106,10 @@ deps = ["Test"]
 git-tree-sha1 = "b8045033701c3b10bf2324d7203404be7aef88ba"
 uuid = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
 version = "0.5.3"
+
+[[Future]]
+deps = ["Random"]
+uuid = "9fa8497b-333b-5362-9e8d-4d0656e87820"
 
 [[GitForge]]
 deps = ["Dates", "HTTP", "JSON2"]
@@ -187,6 +203,12 @@ git-tree-sha1 = "85f5947b53c8cfd53ccfa3f4abae31faa22c2181"
 uuid = "739be429-bea8-5141-9913-cc70e7f3736d"
 version = "0.7.0"
 
+[[Missings]]
+deps = ["DataAPI"]
+git-tree-sha1 = "de0a5ce9e5289f27df672ffabef4d1e5861247d5"
+uuid = "e1d29d7a-bbdc-5cf2-9ac0-f12de2c33e28"
+version = "0.4.3"
+
 [[Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
 
@@ -236,6 +258,11 @@ git-tree-sha1 = "0af826be249c6751a3e783c07b8cd3034f508943"
 uuid = "fc669557-7ec9-5e45-bca9-462afbc28879"
 version = "0.2.0"
 
+[[PooledArrays]]
+git-tree-sha1 = "6e8c38927cb6e9ae144f7277c753714861b27d14"
+uuid = "2dfb63ee-cc39-5dd5-95bd-886bf059d720"
+version = "0.5.2"
+
 [[Printf]]
 deps = ["Unicode"]
 uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
@@ -269,6 +296,12 @@ version = "1.0.0"
 [[SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 
+[[SQLite]]
+deps = ["BinaryProvider", "DataFrames", "Dates", "Libdl", "Random", "Serialization", "Tables", "Test", "WeakRefStrings"]
+git-tree-sha1 = "0b4a56ae5df77c6b725cd22e4734ea137f883c7a"
+uuid = "0aa819cd-b072-5ff4-a722-6bc24af294d9"
+version = "0.8.2"
+
 [[Serialization]]
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 
@@ -279,6 +312,12 @@ uuid = "1a1011a3-84de-559e-8e89-a11a2f7dc383"
 [[Sockets]]
 uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
 
+[[SortingAlgorithms]]
+deps = ["DataStructures", "Random", "Test"]
+git-tree-sha1 = "03f5898c9959f8115e30bc7226ada7d0df554ddd"
+uuid = "a2af1166-a08f-5f64-846c-94a0d3cef48c"
+version = "0.3.1"
+
 [[SparseArrays]]
 deps = ["LinearAlgebra", "Random"]
 uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
@@ -286,6 +325,12 @@ uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 [[Statistics]]
 deps = ["LinearAlgebra", "SparseArrays"]
 uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+
+[[StatsBase]]
+deps = ["DataAPI", "DataStructures", "LinearAlgebra", "Missings", "Printf", "Random", "SortingAlgorithms", "SparseArrays", "Statistics"]
+git-tree-sha1 = "c53e809e63fe5cf5de13632090bc3520649c9950"
+uuid = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
+version = "0.32.0"
 
 [[StructIO]]
 deps = ["Test"]
@@ -338,6 +383,12 @@ deps = ["ColorTypes", "FixedPointNumbers", "REPL", "Test"]
 git-tree-sha1 = "b15606f470e02061183738dd8d6d3ad5e115ed76"
 uuid = "7774df62-37c0-5c21-b34d-f6d7f98f54bc"
 version = "0.3.2"
+
+[[WeakRefStrings]]
+deps = ["Random", "Test"]
+git-tree-sha1 = "9a0bb82eede528debe631b642eeb48a631a69bc2"
+uuid = "ea10d353-3f73-51f8-a26c-33c1cb351aa5"
+version = "0.6.1"
 
 [[WebSockets]]
 deps = ["Base64", "Dates", "Distributed", "HTTP", "Logging", "Random", "Sockets", "Test"]

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -28,17 +28,11 @@ git-tree-sha1 = "5b08ed6036d9d3f0ee6369410b830f8873d4024c"
 uuid = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
 version = "0.5.8"
 
-[[CSTParser]]
-deps = ["Tokenize"]
-git-tree-sha1 = "99dda94f5af21a4565dc2b97edf6a95485f116c3"
-uuid = "00ebfdb7-1f24-5e51-bd34-a7502290713f"
-version = "1.0.0"
-
 [[CategoricalArrays]]
 deps = ["Compat", "DataAPI", "Future", "JSON", "Missings", "Printf", "Reexport", "Unicode"]
-git-tree-sha1 = "45101c4d0df3946acb6e9bfcfd3a8c32abbd421b"
+git-tree-sha1 = "2473560b9c7cb18f98c3c926af0dc7bedccfc7ab"
 uuid = "324d7699-5711-5eae-9e2f-1d82baa6b597"
-version = "0.7.1"
+version = "0.7.2"
 
 [[CodecZlib]]
 deps = ["BinaryProvider", "Libdl", "TranscodingStreams"]
@@ -54,9 +48,9 @@ version = "0.8.0"
 
 [[Compat]]
 deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
-git-tree-sha1 = "0caaa696071d6e7872ddf30e58ed6ec0b49954c4"
+git-tree-sha1 = "ed2c4abadf84c53d9e58510b5fc48912c2336fbb"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "3.0.0"
+version = "2.2.0"
 
 [[DataAPI]]
 git-tree-sha1 = "674b67f344687a88310213ddfa8a2b3c76cc4252"
@@ -64,10 +58,10 @@ uuid = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
 version = "1.1.0"
 
 [[DataFrames]]
-deps = ["CategoricalArrays", "Compat", "IteratorInterfaceExtensions", "Missings", "PooledArrays", "Printf", "REPL", "Reexport", "SortingAlgorithms", "Statistics", "StatsBase", "TableTraits", "Tables", "Unicode"]
-git-tree-sha1 = "7c0f86a01be0f77cc7f3f9096ed875f1217487e1"
+deps = ["CategoricalArrays", "Compat", "DataAPI", "InvertedIndices", "IteratorInterfaceExtensions", "Missings", "PooledArrays", "Printf", "REPL", "Reexport", "SortingAlgorithms", "Statistics", "TableTraits", "Tables", "Unicode"]
+git-tree-sha1 = "271528230c65a4517522e2968c3deed76b92b998"
 uuid = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
-version = "0.18.4"
+version = "0.19.4"
 
 [[DataStructures]]
 deps = ["InteractiveUtils", "OrderedCollections"]
@@ -145,6 +139,12 @@ version = "0.5.0"
 deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
+[[InvertedIndices]]
+deps = ["Test"]
+git-tree-sha1 = "15732c475062348b0165684ffe28e85ea8396afc"
+uuid = "41ab1584-1d38-5bbf-9106-f11c6c58b48f"
+version = "1.0.0"
+
 [[IteratorInterfaceExtensions]]
 git-tree-sha1 = "a3f24677c21f5bbe9d2a714f95dcd58337fb2856"
 uuid = "82899510-4779-5014-852e-03e436cf321d"
@@ -188,10 +188,10 @@ uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
 
 [[MacroTools]]
-deps = ["CSTParser", "Compat", "DataStructures", "Test", "Tokenize"]
-git-tree-sha1 = "d6e9dedb8c92c3465575442da456aec15a89ff76"
+deps = ["Compat", "DataStructures", "Test"]
+git-tree-sha1 = "82921f0e3bde6aebb8e524efc20f4042373c0c06"
 uuid = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
-version = "0.5.1"
+version = "0.5.2"
 
 [[Markdown]]
 deps = ["Base64"]
@@ -326,12 +326,6 @@ uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 deps = ["LinearAlgebra", "SparseArrays"]
 uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
-[[StatsBase]]
-deps = ["DataAPI", "DataStructures", "LinearAlgebra", "Missings", "Printf", "Random", "SortingAlgorithms", "SparseArrays", "Statistics"]
-git-tree-sha1 = "c53e809e63fe5cf5de13632090bc3520649c9950"
-uuid = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
-version = "0.32.0"
-
 [[StructIO]]
 deps = ["Test"]
 git-tree-sha1 = "010dc73c7146869c042b49adcdb6bf528c12e859"
@@ -359,11 +353,6 @@ deps = ["Dates", "Test"]
 git-tree-sha1 = "43defcaf72b89b047f11b778cd83b71ac3e418b0"
 uuid = "37f0c46e-897f-50ef-b453-b26c3eed3d6c"
 version = "0.2.0"
-
-[[Tokenize]]
-git-tree-sha1 = "dfcdbbfb2d0370716c815cbd6f8a364efb6f42cf"
-uuid = "0796e94c-ce3b-5d07-9a54-7f471281c624"
-version = "0.5.6"
 
 [[TranscodingStreams]]
 deps = ["Random", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,7 @@ BinaryBuilder = "12aac903-9f7c-5d81-afc2-d9565ea332ae"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+SQLite = "0aa819cd-b072-5ff4-a722-6bc24af294d9"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 
 [deps]
 BinaryBuilder = "12aac903-9f7c-5d81-afc2-d9565ea332ae"
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ In order to run PkgEval against a Julia package do the following:
 
     You have three choices. Either you use a specific version of Julia that has been
     registered in `Versions.toml` already, and will automatically be downloaded, verified
-    and unpacked when required as such:
+    and unpacked when required using the `obtain_julia` function:
 
     ```jl
     import NewPkgEval
@@ -30,8 +30,8 @@ In order to run PkgEval against a Julia package do the following:
     the exact version number you should use with other functions in NewPkgEval:
 
     ```jl
-    ver = NewPkgEval.download_julia("latest")
-    NewPkgEval.run(..., ver, ...)
+    julia = NewPkgEval.download_julia("latest")
+    NewPkgEval.run(julia, ...)
     ```
 
     It also adds an entry to Versions.toml:
@@ -48,7 +48,7 @@ In order to run PkgEval against a Julia package do the following:
     you should then use:
 
     ```jl
-    ver = NewPkgEval.build_julia("master")
+    julia = NewPkgEval.build_julia("master")
     ```
 
     If you get a permission error, try to set the variable
@@ -66,7 +66,7 @@ In order to run PkgEval against a Julia package do the following:
     To see that things work as expected, try to run
 
     ```
-    julia> NewPkgEval.run_sandboxed_julia(`-e 'print("hello")'`; ver=ver);
+    julia> NewPkgEval.run_sandboxed_julia(julia, `-e 'print("hello")'`);
     hello
     ```
 
@@ -77,9 +77,7 @@ In order to run PkgEval against a Julia package do the following:
 
     ```julia
     using NewPkgEval
-    NewPkgEval.get_registry(update=true)
-    pkgs = NewPkgEval.read_pkgs(); # can also give a vector of packages here
-    results = NewPkgEval.run(pkgs, 20, v"1.2.0")
+    results = NewPkgEval.run(v"1.2.0") # pass an array of package names to limit the run
     ```
 
     See the docstrings for more arguments.

--- a/README.md
+++ b/README.md
@@ -13,22 +13,42 @@ In order to run PkgEval against a Julia package do the following:
     ```
 
 
-2. Build a julia binary distribution
+2. Obtain a binary Julia distribution
 
-    You have two choices. Either you build a binary distribution of julia yourself
-    (or let the buildbots do it), or you may use NewPkgEval to do it for you:
+    You have three choices. Either you use a specific version of Julia that has been
+    registered in `Versions.toml` already, and will automatically be downloaded, verified
+    and unpacked when required as such:
 
     ```jl
     import NewPkgEval
-    NewPkgEval.build_julia(ref="master"; binarybuilder_args=String["--verbose"])
+    NewPkgEval.obtain_julia(v"1.2.0")
     ```
 
-    where `ref` is a GitHub reference (branch, commit or tag, for example `"v1.2.0"`).
-    This will register a in deps/Versions.toml, using a stanza that looks like so:
+    If you want to use an unreleased version of Julia as provided by the build bots, you can
+    add or use an entry from `Builds.toml` and call `download_julia`. The exact version of
+    these entries is often not known beforehand, and because of that the function returns
+    the exact version number you should use with other functions in NewPkgEval:
+
+    ```jl
+    ver = NewPkgEval.download_julia("latest")
+    NewPkgEval.run(..., ver, ...)
     ```
-    ["1.2.0"]
-    file = "julia.v1.2.0.x86_64-linux-gnu.tar.gz"
-    sha = "9c796bfd7cb53604d6b176c45d38069d8f816efbe69d717b92d713bc080c89eb"
+
+    It also adds an entry to Versions.toml:
+
+    ```
+    ["1.4.0-DEV-8f7855a7c3"]
+    file = "julia-1.4.0-DEV-8f7855a7c3.tar.gz"
+    sha = "dcd105b94906359cae52656129615a1446e7aee1e992ae9c06a15554d83a46f0"
+
+    ```
+
+    Finally, you can also build Julia from Git using BinaryBuilder using the `build_julia`
+    method. Similarly, it adds an entry to Versions.toml and returns the version identifier
+    you should then use:
+
+    ```jl
+    ver = NewPkgEval.build_julia("master")
     ```
 
     If you get a permission error, try to set the variable
@@ -46,7 +66,7 @@ In order to run PkgEval against a Julia package do the following:
     To see that things work as expected, try to run
 
     ```
-    julia> NewPkgEval.run_sandboxed_julia(`-e 'print("hello")'`; ver=v);
+    julia> NewPkgEval.run_sandboxed_julia(`-e 'print("hello")'`; ver=ver);
     hello
     ```
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ In order to run PkgEval against a Julia package do the following:
     manually and copy the tarball from the products/ directory into `deps/downloads`.
 
 
-3. Try the julia sandbox environment
+3. Try the Julia sandbox environment
 
     To see that things work as expected, try to run
 
@@ -77,6 +77,7 @@ In order to run PkgEval against a Julia package do the following:
 
     ```julia
     using NewPkgEval
+    NewPkgEval.get_registry(update=true)
     pkgs = NewPkgEval.read_pkgs(); # can also give a vector of packages here
     results = NewPkgEval.run(pkgs, 20, v"1.2.0")
     ```

--- a/bin/test.jl
+++ b/bin/test.jl
@@ -1,5 +1,6 @@
 # script that tests all packages and writes the results to a database file
 
+using DataFrames
 using NewPkgEval
 using SQLite
 using Dates
@@ -23,23 +24,29 @@ function main(;pkgnames=["Example"], julia_releases=["1.2"], registry="General",
     # prepare the database
     SQLite.execute!(db, """
         CREATE TABLE IF NOT EXISTS builds (package_name TEXT,
+                                           package_version TEXT,
                                            julia_release TEXT,
                                            julia_version TEXT,
+                                           run INT,
                                            status TEXT,
                                            log TEXT,
                                            datetime TEXT,
                                            duration REAL)
         """)
 
+    # find a unique run identifier
+    run = (SQLite.Query(db, "SELECT COALESCE(MAX(run), 0) FROM builds") |> DataFrame)[1,1] + 1
+
     # test!
     for (julia_release, julia_version) in julia_versions
-        function store_result(package, start, status, log)
+        function store_result(package_name, package_version, start, status, log)
             stop = now()
             elapsed = (stop-start) / Millisecond(1000)
 
-            SQLite.Query(db, "INSERT INTO builds VALUES (?, ?, ?, ?, ?, ?, ?)";
-                         values=[package, julia_release, string(julia_version),
-                                 string(status), log, string(now()), elapsed])
+            SQLite.Query(db, "INSERT INTO builds VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)";
+                         values=[package_name, string(package_version),
+                                 julia_release, string(julia_version),
+                                 run, string(status), log, string(now()), elapsed])
         end
 
         NewPkgEval.run(julia_version, pkgs; callback=store_result)

--- a/bin/test.jl
+++ b/bin/test.jl
@@ -44,7 +44,8 @@ function main(;pkgnames=["Example"], julia_releases=["1.2"], registry="General",
             elapsed = (stop-start) / Millisecond(1000)
 
             SQLite.Query(db, "INSERT INTO builds VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)";
-                         values=[package_name, string(package_version),
+                         values=[package_name,
+                                 ismissing(package_version) ? missing : string(package_version),
                                  julia_release, string(julia_version),
                                  run, string(status), log, string(now()), elapsed])
         end

--- a/bin/test.jl
+++ b/bin/test.jl
@@ -1,0 +1,51 @@
+# script that tests all packages and writes the results to a database file
+
+using NewPkgEval
+using SQLite
+using Dates
+
+function main(;pkgnames=["Example"], julia_releases=["1.2"], registry="General", dbfile=nothing)
+    db = if dbfile === nothing
+        # in memory
+        SQLite.DB()
+    else
+        SQLite.DB(dbfile)
+    end
+
+    # get the Julia versions
+    julia_versions = Dict(julia_release => NewPkgEval.download_julia(julia_release)
+                          for julia_release in julia_releases)
+
+    # get the packages
+    NewPkgEval.get_registry(update=true)
+    pkgs = NewPkgEval.read_pkgs(pkgnames)
+
+    # prepare the database
+    SQLite.execute!(db, """
+        CREATE TABLE IF NOT EXISTS builds (package_name TEXT,
+                                           julia_release TEXT,
+                                           julia_version TEXT,
+                                           status TEXT,
+                                           log TEXT,
+                                           datetime TEXT,
+                                           duration REAL)
+        """)
+
+    # test!
+    for (julia_release, julia_version) in julia_versions
+        function store_result(package, start, status, log)
+            stop = now()
+            elapsed = (stop-start) / Millisecond(1000)
+
+            SQLite.Query(db, "INSERT INTO builds VALUES (?, ?, ?, ?, ?, ?, ?)";
+                         values=[package, julia_release, string(julia_version),
+                                 string(status), log, string(now()), elapsed])
+        end
+
+        NewPkgEval.run(julia_version, pkgs; callback=store_result)
+    end
+
+    return
+end
+
+isinteractive() || main(pkgnames=nothing, dbfile=joinpath(@__DIR__, "test.db"))

--- a/deps/Builds.toml
+++ b/deps/Builds.toml
@@ -1,0 +1,5 @@
+["1.3"]
+url = "https://julialang-s3.julialang.org/bin/linux/x64/1.3/julia-1.3-latest-linux-x86_64.tar.gz"
+
+["latest"]
+url = "https://julialangnightlies-s3.julialang.org/bin/linux/x64/julia-latest-linux64.tar.gz"

--- a/deps/Builds.toml
+++ b/deps/Builds.toml
@@ -1,3 +1,12 @@
+["1.0"]
+url = "https://julialang-s3.julialang.org/bin/linux/x64/1.0/julia-1.0-latest-linux-x86_64.tar.gz"
+
+["1.1"]
+url = "https://julialang-s3.julialang.org/bin/linux/x64/1.1/julia-1.1-latest-linux-x86_64.tar.gz"
+
+["1.2"]
+url = "https://julialang-s3.julialang.org/bin/linux/x64/1.2/julia-1.2-latest-linux-x86_64.tar.gz"
+
 ["1.3"]
 url = "https://julialang-s3.julialang.org/bin/linux/x64/1.3/julia-1.3-latest-linux-x86_64.tar.gz"
 

--- a/deps/Registries.toml
+++ b/deps/Registries.toml
@@ -2,6 +2,7 @@
 url = "https://github.com/JuliaRegistries/General.git"
 uuid = "23338594-aafe-5451-b93e-139f81909106"
 skip = [
+    "julia", # really crappy software
     "AbstractAlgebra", # Hangs forever
     "DiscretePredictors", # Hangs forever
     "LinearLeastSquares", # Hangs forever

--- a/deps/Versions.toml
+++ b/deps/Versions.toml
@@ -1,18 +1,11 @@
 ["1.0.5"]
-file = "julia-1.0.5-linux-x86_64.tar.gz"
 url = "https://julialang-s3.julialang.org/bin/linux/x64/1.0/julia-1.0.5-linux-x86_64.tar.gz"
 sha = "9dedd613777ba6ebd8aee5796915ff50aa6188ea03ed143cb687fc2aefd76b03"
 
 ["1.2.0"]
-file = "julia-1.2.0.linux-x86_64.tar.gz"
 url = "https://julialang-s3.julialang.org/bin/linux/x64/1.2/julia-1.2.0-linux-x86_64.tar.gz"
 sha = "926ced5dec5d726ed0d2919e849ff084a320882fb67ab048385849f9483afc47"
 
 ["1.3.0-rc5"]
-file = "julia-1.3.0-rc5.linux-x86_64.tar.gz"
 url = "https://julialang-s3.julialang.org/bin/linux/x64/1.3/julia-1.3.0-rc5-linux-x86_64.tar.gz"
 sha = "164599f6c5458a664a6b05377661ed7b4df8a65c76af090962c11a1094ae7981"
-
-["nightly"]
-file = "julia-latest-linux64.tar.gz"
-url = "https://julialangnightlies-s3.julialang.org/bin/linux/x64/julia-latest-linux64.tar.gz"

--- a/src/NewPkgEval.jl
+++ b/src/NewPkgEval.jl
@@ -45,7 +45,7 @@ end
 """
     read_versions() -> Dict
 
-Parse the `deps/Versions.toml` file containing version and download information for
+Parse the `deps/Versions.toml` file containing download and verification information for
 various versions of Julia.
 """
 read_versions() = TOML.parse(read(versions_file(), String))
@@ -53,11 +53,16 @@ read_versions() = TOML.parse(read(versions_file(), String))
 """
     read_registries() -> Dict
 
-Parse the `deps/Registries.toml` file containing a URL and packages to skip or assume
-passing for listed registries.
+Parse the `deps/Registries.toml` file containing a URL and packages to skip for listed
+registries.
 """
 read_registries() = TOML.parsefile(registries_file())
 
+"""
+    read_builds() -> Dict
+
+Parse the `deps/Builds.toml` file containing download information for various Julia builds.
+"""
 read_builds() = TOML.parsefile(builds_file())
 
 function installed_julia_dir(ver)

--- a/src/NewPkgEval.jl
+++ b/src/NewPkgEval.jl
@@ -14,6 +14,7 @@ versions_file() = joinpath(@__DIR__, "..", "deps", "Versions.toml")
 registry_path(name) = joinpath(first(DEPOT_PATH), "registries", name)
 registries_file() = joinpath(@__DIR__, "..", "deps", "Registries.toml")
 builds_file() = joinpath(@__DIR__, "..", "deps", "Builds.toml")
+log_path(julia) = joinpath(@__DIR__, "..", "logs/logs-$julia")
 
 # Skip these packages when testing packages
 const skip_lists = Dict{String,Vector{String}}()
@@ -84,7 +85,10 @@ package name and registry, its UUID, and a path to it. If `pkgs` is given, only 
 packages matching the names in `pkgs`
 """
 function read_pkgs(pkgs::Union{Nothing, Vector{String}}=nothing; registry=DEFAULT_REGISTRY)
-    ispath(registry_path(registry)) || error("Please run `NewPkgEval.get_registry()` first")
+    get_registry(registry)
+    if pkgs !== nothing
+        pkgs = copy(pkgs)
+    end
 
     pkg_data = []
     regpath = registry_path(registry)

--- a/src/NewPkgEval.jl
+++ b/src/NewPkgEval.jl
@@ -6,8 +6,6 @@ using Pkg
 import Base: UUID
 using Dates
 
-const DEFAULT_REGISTRY = "General"
-
 downloads_dir(name) = joinpath(@__DIR__, "..", "deps", "downloads", name)
 julia_path(ver) = joinpath(@__DIR__, "..", "deps", "julia-$ver")
 versions_file() = joinpath(@__DIR__, "..", "deps", "Versions.toml")
@@ -15,33 +13,6 @@ registry_path(name) = joinpath(first(DEPOT_PATH), "registries", name)
 registries_file() = joinpath(@__DIR__, "..", "deps", "Registries.toml")
 builds_file() = joinpath(@__DIR__, "..", "deps", "Builds.toml")
 log_path(julia) = joinpath(@__DIR__, "..", "logs/logs-$julia")
-
-# Skip these packages when testing packages
-const skip_lists = Dict{String,Vector{String}}()
-
-"""
-    get_registry([name]; update=false)
-
-Download the given registry, or if it already exists, update it if `update` is true.
-`name` must correspond to an existing stanza in the `deps/Registries.toml` file.
-"""
-function get_registry(name=DEFAULT_REGISTRY; update=false)
-    reg = read_registries()[name]
-    regspec = RegistrySpec(name = name, url = reg["url"], uuid = UUID(reg["uuid"]))
-
-    # clone and update the registry
-    if !any(existing_regspec -> existing_regspec.name == name, Pkg.Types.collect_registries())
-        Pkg.Types.clone_or_cp_registries([regspec])
-    elseif update
-        Pkg.UPDATED_REGISTRY_THIS_SESSION[] = false
-        Pkg.Types.update_registries(Pkg.Types.Context(), [regspec])
-    end
-
-    # read some metadata
-    skip_lists[name] = get(reg, "skip", String[])
-
-    return
-end
 
 """
     read_versions() -> Dict
@@ -66,53 +37,8 @@ Parse the `deps/Builds.toml` file containing download information for various Ju
 """
 read_builds() = TOML.parsefile(builds_file())
 
-function installed_julia_dir(ver)
-     jp = julia_path(ver)
-     jp_contents = readdir(jp)
-     # Allow the unpacked directory to either be insider another directory (as produced by
-     # the buildbots) or directly inside the mapped directory (as produced by the BB script)
-     if length(jp_contents) == 1
-         jp = joinpath(jp, first(jp_contents))
-     end
-     jp
-end
-
-"""
-    read_pkgs([pkgs::Vector{String}]; [registry::String])
-
-Read all packages from a registry and return them as a vector of tuples containing the
-package name and registry, its UUID, and a path to it. If `pkgs` is given, only collect
-packages matching the names in `pkgs`
-"""
-function read_pkgs(pkgs::Union{Nothing, Vector{String}}=nothing; registry=DEFAULT_REGISTRY)
-    get_registry(registry)
-    if pkgs !== nothing
-        pkgs = copy(pkgs)
-    end
-
-    pkg_data = []
-    regpath = registry_path(registry)
-    open(joinpath(regpath, "Registry.toml")) do io
-        for (_uuid, pkgdata) in Pkg.Types.read_registry(joinpath(regpath, "Registry.toml"))["packages"]
-            uuid = UUID(_uuid)
-            name = pkgdata["name"]
-            if pkgs !== nothing
-                idx = findfirst(==(name), pkgs)
-                idx === nothing && continue
-                deleteat!(pkgs, idx)
-            end
-            path = abspath(regpath, pkgdata["path"])
-            push!(pkg_data, (name=name, uuid=uuid, path=path, registry=registry))
-        end
-    end
-    if pkgs !== nothing && !isempty(pkgs)
-        @warn """did not find the following packages in the $registry registry:\n $("  - " .* join(pkgs, '\n'))"""
-    end
-
-    return pkg_data
-end
-
-include("build.jl")
+include("registry.jl")
+include("julia.jl")
 include("run.jl")
 
 end # module

--- a/src/build.jl
+++ b/src/build.jl
@@ -1,11 +1,122 @@
 using BinaryBuilder
 using LibGit2
+import SHA: sha256
+
+function filehash(path)
+    open(path, "r") do f
+        bytes2hex(sha256(f))
+    end
+end
 
 """
-    version_id = build_julia(ref::String="master"; binarybuilder_args::Vector{String}=String["--verbose"])
+    obtain_julia(the_ver)
 
-Download and build julia at git reference `ref` using BinaryBuilder. Return the `version_id`
-(what other functions use to identify this build).
+Download the specified version of Julia using the information provided in `Versions.toml`.
+"""
+function obtain_julia(the_ver::VersionNumber)
+    vers = read_versions()
+    for (ver, data) in vers
+        ver == string(the_ver) || continue
+        dir = julia_path(ver)
+        mkpath(dirname(dir))
+        if haskey(data, "url")
+            url = data["url"]
+
+            file = get(data, "file", "julia-$ver.tar.gz")
+            @assert !isabspath(file)
+            file = downloads_dir(file)
+            mkpath(dirname(file))
+
+            Pkg.PlatformEngines.download_verify_unpack(url, data["sha"], dir;
+                                                        tarball_path=file, force=true)
+        else
+            file = data["file"]
+            !isabspath(file) && (file = downloads_dir(file))
+            Pkg.PlatformEngines.verify(file, data["sha"])
+            isdir(dir) || Pkg.PlatformEngines.unpack(file, dir)
+        end
+        return
+    end
+    error("Requested Julia version not found")
+end
+
+"""
+    version = download_julia(name::String)
+
+Download Julia from an on-line source listed in Builds.toml as identified by `name`.
+Returns the `version` (what other functions use to identify this build).
+This version will be added to Versions.toml.
+"""
+
+function download_julia(name::String)
+    builds = read_builds()
+    @assert haskey(builds, name) "Julia build $name is not registered in Builds.toml"
+    data = builds[name]
+
+    # get the filename and extension from the url
+    url = data["url"]
+    name = basename(url)
+    dot_idx = findfirst(isequal('.'), name)
+    ext = name[dot_idx+1:end]
+    name = name[1:dot_idx-1]
+
+    # download
+    temp_file = downloads_dir(name)
+    mkpath(dirname(temp_file))
+    ispath(temp_file) && rm(temp_file)
+    Pkg.PlatformEngines.download(url, temp_file)
+
+    # unpack
+    temp_dir = julia_path(name)
+    ispath(temp_dir) && rm(temp_dir; recursive=true)
+    Pkg.PlatformEngines.unpack(temp_file, temp_dir)
+
+    # figure out stuff from the downloaded binary
+    version = VersionNumber(read(`$(installed_julia_dir(name))/bin/julia -e 'print(Base.VERSION_STRING)'`, String))
+    if version.prerelease != ()
+        commit_short = read(`$(installed_julia_dir(name))/bin/julia -e 'print(Base.GIT_VERSION_INFO.commit_short)'`, String)
+        version = VersionNumber(string(version) * string("-", commit_short))
+    end
+    rm(temp_dir; recursive=true) # let `obtain_julia` unpack; keeps code simpler here
+
+    versions = read_versions()
+    if haskey(versions, string(version))
+        @info "Julia $name (version $version) already available"
+        rm(temp_file)
+    else
+        # always use the hash of the downloaded file to force a check during `obtain_julia`
+        hash = filehash(temp_file)
+
+        # move to its final location
+        name = "julia-$version.$ext"
+        file = downloads_dir(name)
+        if ispath(file)
+            @warn "Destination file $name already exists, assuming it matches"
+            rm(temp_file)
+        else
+            mv(temp_file, file)
+        end
+
+        # Update Versions.toml
+        version_stanza = """
+            ["$version"]
+            file = "$name"
+            sha = "$hash"
+            """
+        open(versions_file(); append=true) do f
+            println(f, version_stanza)
+        end
+    end
+
+    return version
+end
+
+"""
+    version = build_julia(ref::String="master"; binarybuilder_args::Vector{String}=String["--verbose"])
+
+Check-out and build Julia at git reference `ref` using BinaryBuilder.
+Returns the `version` (what other functions use to identify this build).
+This version will be added to Versions.toml.
 """
 function build_julia(ref::String="master"; binarybuilder_args::Vector{String}=String["--verbose"])
     # get the Julia repo
@@ -22,29 +133,21 @@ function build_julia(ref::String="master"; binarybuilder_args::Vector{String}=St
     reference = LibGit2.GitCommit(repo, ref)
     tree = LibGit2.peel(LibGit2.GitTree, reference)
     version = VersionNumber(chomp(LibGit2.content(tree["VERSION"])))
-    commit_hash = string(LibGit2.GitHash(reference))
-
+    commit = string(LibGit2.GitHash(reference))
     if version.prerelease != ()
-        contrib_path = joinpath(Sys.BINDIR, "..", "..", "contrib")
-        found_buildname = false
-        if isdir(contrib_path)
-            try
-                cd(contrib_path) do
-                    version = VersionNumber(read(`./commit-name.sh $commit_hash`, String))
-                end
-                found_buildname = true
-            catch e
-                @error "failed to get build number" exception=e
-            end
-        end
-        if !found_buildname
-            version = VersionNumber(string(version) * string("-", commit_hash[1:6]))
-        end
+        commit_short = commit[1:10]
+        version = VersionNumber(string(version) * string("-", commit_short))
+    end
+
+    versions = read_versions()
+    if haskey(versions, string(version))
+        @info "Julia $ref (version $version) already available"
+        return version
     end
 
     # Collection of sources required to build julia
     sources = [
-        "https://github.com/JuliaLang/julia.git" => commit_hash,
+        "https://github.com/JuliaLang/julia.git" => commit,
     ]
 
     # Bash recipe for building across all platforms
@@ -72,46 +175,38 @@ function build_julia(ref::String="master"; binarybuilder_args::Vector{String}=St
     ]
 
     # The products that we will ensure are always built
-    products = [
+    products = Product[
         ExecutableProduct("julia", :julia)
     ]
 
     # Dependencies that must be installed before this package can be built
     dependencies = []
 
-    # Build the tarballs, and possibly a `build.jl` as well.
+    # Build the tarballs
     product_hashes = cd(joinpath(@__DIR__, "..", "deps")) do
         build_tarballs(binarybuilder_args, "julia", version, sources, script, platforms, products, dependencies, preferred_gcc_version=v"7", skip_audit=true)
     end
-    tarball, hash = product_hashes[platforms[1]]
-    version = string(version)
+    temp_file, hash = product_hashes[platforms[1]]
+    name = basename(temp_file)
 
     # Update Versions.toml
     version_stanza = """
         ["$version"]
-        file = "$tarball"
+        file = "$name"
         sha = "$hash"
-    """
-    if haskey(read_versions(), version)
-        # TODO: overwrite automatically, since the hash will have changed
-        @warn "$version already exists in Versions.toml. Not adding."
-        println("You may manually add the following stanza to $(versions_file()):")
-        println(version_stanza)
-    else
-        open(versions_file(); append=true) do f
-            println(f, version_stanza)
-        end
+        """
+    open(versions_file(); append=true) do f
+        println(f, version_stanza)
     end
 
     # Copy the generated tarball to the downloads folder
-    download_path = joinpath(@__DIR__, "..", "deps", "downloads")
-    if isfile(joinpath(download_path, tarball))
-        @warn "$tarball already exists in deps/downloads folder. Not copying."
-        println("You may manually copy the file from products/.")
-    else
-        mkpath(download_path)
-        cp(joinpath(@__DIR__, "..", "deps", "products", tarball), joinpath(download_path, tarball))
+    file = downloads_dir(name)
+    if ispath(file)
+        # NOTE: we can't use the previous file here (like in `download_julia`)
+        #       because the hash will most certainly be different
+        @warn "Destination file $name already exists, overwriting"
     end
+    mv(temp_file, file)
 
     return version
 end

--- a/src/julia.jl
+++ b/src/julia.jl
@@ -1,4 +1,3 @@
-using BinaryBuilder
 using LibGit2
 import SHA: sha256
 
@@ -6,6 +5,17 @@ function filehash(path)
     open(path, "r") do f
         bytes2hex(sha256(f))
     end
+end
+
+function installed_julia_dir(ver)
+     jp = julia_path(ver)
+     jp_contents = readdir(jp)
+     # Allow the unpacked directory to either be insider another directory (as produced by
+     # the buildbots) or directly inside the mapped directory (as produced by the BB script)
+     if length(jp_contents) == 1
+         jp = joinpath(jp, first(jp_contents))
+     end
+     jp
 end
 
 """

--- a/src/registry.jl
+++ b/src/registry.jl
@@ -1,0 +1,63 @@
+const DEFAULT_REGISTRY = "General"
+
+# Skip these packages when testing packages
+const skip_lists = Dict{String,Vector{String}}()
+
+"""
+    get_registry([name]; update=false)
+
+Download the given registry, or if it already exists, update it if `update` is true.
+`name` must correspond to an existing stanza in the `deps/Registries.toml` file.
+"""
+function get_registry(name=DEFAULT_REGISTRY; update=false)
+    reg = read_registries()[name]
+    regspec = RegistrySpec(name = name, url = reg["url"], uuid = UUID(reg["uuid"]))
+
+    # clone and update the registry
+    if !any(existing_regspec -> existing_regspec.name == name, Pkg.Types.collect_registries())
+        Pkg.Types.clone_or_cp_registries([regspec])
+    elseif update
+        Pkg.UPDATED_REGISTRY_THIS_SESSION[] = false
+        Pkg.Types.update_registries(Pkg.Types.Context(), [regspec])
+    end
+
+    # read some metadata
+    skip_lists[name] = get(reg, "skip", String[])
+
+    return
+end
+
+"""
+    read_pkgs([pkgs::Vector{String}]; [registry::String])
+
+Read all packages from a registry and return them as a vector of tuples containing the
+package name and registry, its UUID, and a path to it. If `pkgs` is given, only collect
+packages matching the names in `pkgs`
+"""
+function read_pkgs(pkgs::Union{Nothing, Vector{String}}=nothing; registry=DEFAULT_REGISTRY)
+    get_registry(registry)
+    if pkgs !== nothing
+        pkgs = copy(pkgs)
+    end
+
+    pkg_data = []
+    regpath = registry_path(registry)
+    open(joinpath(regpath, "Registry.toml")) do io
+        for (_uuid, pkgdata) in Pkg.Types.read_registry(joinpath(regpath, "Registry.toml"))["packages"]
+            uuid = UUID(_uuid)
+            name = pkgdata["name"]
+            if pkgs !== nothing
+                idx = findfirst(==(name), pkgs)
+                idx === nothing && continue
+                deleteat!(pkgs, idx)
+            end
+            path = abspath(regpath, pkgdata["path"])
+            push!(pkg_data, (name=name, uuid=uuid, path=path, registry=registry))
+        end
+    end
+    if pkgs !== nothing && !isempty(pkgs)
+        @warn """did not find the following packages in the $registry registry:\n $("  - " .* join(pkgs, '\n'))"""
+    end
+
+    return pkg_data
+end

--- a/src/run.jl
+++ b/src/run.jl
@@ -219,8 +219,8 @@ function run(julia::VersionNumber, pkgs::Vector; ninstances::Integer=Sys.CPU_THR
                     while !isempty(pkgs) && !done
                         pkg = pop!(pkgs)
                         times[i] = now()
-                        log = nothing
-                        pkg_version = nothing
+                        log = missing
+                        pkg_version = missing
                         if pkg.name in skip_lists[pkg.registry]
                             result[pkg.name] = :skip
                         else

--- a/src/run.jl
+++ b/src/run.jl
@@ -155,9 +155,9 @@ function run(julia::VersionNumber, pkgs::Vector; ninstances::Integer=Sys.CPU_THR
     function update_output()
         # known statuses
         o = count(==(:ok),      values(result))
+        f = count(==(:fail),    values(result))
+        k = count(==(:killed),  values(result))
         s = count(==(:skipped), values(result))
-        # everything else is a failure
-        f = length(result) - (o + s)
         # remaining
         x = npkgs - (o + f + s)
 
@@ -172,13 +172,15 @@ function run(julia::VersionNumber, pkgs::Vector; ninstances::Integer=Sys.CPU_THR
         end
 
         if on_ci
-            println("$x packages to test ($o succeeded, $f failed, $s skipped, $(runtimestr(start)))")
+            println("$x packages to test ($o succeeded, $f failed, $k killed, $s skipped, $(runtimestr(start)))")
             sleep(10)
         else
             print(io, "Success: ")
             printstyled(io, o; color = :green)
             print(io, "\tFailed: ")
             printstyled(io, f; color = Base.error_color())
+            print(io, "\tKilled: ")
+            printstyled(io, k; color = Base.error_color())
             print(io, "\tSkipped: ")
             printstyled(io, s; color = Base.warn_color())
             println(io, "\tRemaining: ", x)

--- a/src/run.jl
+++ b/src/run.jl
@@ -8,33 +8,33 @@ function with_mounted_shards(f, runner)
 end
 
 """
-    run_sandboxed_julia(args=``; ver::String, do_obtain=true, kwargs...)
+    run_sandboxed_julia(julia::VersionNumber, args=``; do_obtain=true, kwargs...)
 
 Run Julia inside of a sandbox, passing the given arguments `args` to it. The keyword
-argument `ver` specifies the version of Julia to use, and `do_obtain` dictates whether
+argument `julia` specifies the version of Julia to use, and `do_obtain` dictates whether
 the specified version should first be downloaded. If `do_obtain` is `false`, it must
 already be installed.
 """
-function run_sandboxed_julia(args=``; ver::VersionNumber, do_obtain=true,
-                             stdin=stdin, stdout=stdout, stderr=stderr)
-    runner, cmd = runner_sandboxed_julia(args; ver=ver, do_obtain=do_obtain)
+function run_sandboxed_julia(julia::VersionNumber, args=``; stdin=stdin, stdout=stdout,
+                             stderr=stderr, kwargs...)
+    runner, cmd = runner_sandboxed_julia(julia, args; kwargs...)
     with_mounted_shards(runner) do
         Base.run(pipeline(cmd, stdin=stdin, stdout=stdout, stderr=stderr))
     end
 end
 
-function runner_sandboxed_julia(args=``; ver::VersionNumber, do_obtain=true)
+function runner_sandboxed_julia(julia::VersionNumber, args=``; do_obtain=true)
     if do_obtain
-        obtain_julia(ver)
+        obtain_julia(julia)
     else
-        @assert ispath(julia_path(ver))
+        @assert ispath(julia_path(julia))
     end
     tmpdir = joinpath(tempdir(), "NewPkgEval")
     mkpath(tmpdir)
     tmpdir = mktempdir(tmpdir)
     runner = BinaryBuilder.UserNSRunner(tmpdir,
         workspaces=[
-            installed_julia_dir(ver)                    => "/maps/julia",
+            installed_julia_dir(julia)                    => "/maps/julia",
             joinpath(first(DEPOT_PATH), "registries")   => "/maps/registries"
         ])
     cmd = `/maps/julia/bin/julia --color=yes $args`
@@ -42,22 +42,20 @@ function runner_sandboxed_julia(args=``; ver::VersionNumber, do_obtain=true)
     return runner, cmd
 end
 
-log_path(ver) = joinpath(@__DIR__, "..", "logs/logs-$ver")
-
 """
-    run_sandboxed_test(pkg; ver::String, do_depwarns=false, log_limit = 5*1024^2, time_limit=60*45, kwargs...)
+    run_sandboxed_test(julia::VersionNumber, pkg; do_depwarns=false, log_limit=5*1024^2, time_limit=60*45)
 
 Run the unit tests for a single package `pkg` inside of a sandbox using the Julia version
-`ver`. If `do_depwarns` is `true`, deprecation warnings emitted while running the package's
+`julia`. If `do_depwarns` is `true`, deprecation warnings emitted while running the package's
 tests will cause the tests to fail. Test will be forcibly interrupted after `time_limit`
 seconds or if the log becomes larger than `log_limit`.
 
 A log for the tests is written to a version-specific directory in the NewPkgEval root
 directory.
 """
-function run_sandboxed_test(pkg::String; ver::VersionNumber, log_limit = 5*1024^2 #= 5 MB =#,
+function run_sandboxed_test(julia::VersionNumber, pkg::String; log_limit = 5*1024^2 #= 5 MB =#,
                             time_limit = 45*60, do_depwarns=false, kwargs...)
-    mkpath(log_path(ver))
+    mkpath(log_path(julia))
     arg = """
         using Pkg
 
@@ -74,9 +72,9 @@ function run_sandboxed_test(pkg::String; ver::VersionNumber, log_limit = 5*1024^
     """
     cmd = do_depwarns ? `--depwarn=error` : ``
     cmd = `$cmd -e $arg`
-    runner, cmd = runner_sandboxed_julia(cmd; ver=ver, kwargs...)
+    runner, cmd = runner_sandboxed_julia(julia, cmd; kwargs...)
 
-    log = joinpath(log_path(ver), "$pkg.log")
+    log = joinpath(log_path(julia), "$pkg.log")
     open(log, "w") do f
         with_mounted_shards(runner) do
             p = Base.run(pipeline(cmd, stdout=f, stderr=f, stdin=devnull); wait=false)
@@ -121,25 +119,12 @@ function kill_process(p)
     end
 end
 
-"""
-    run(depsgraph, ninstances, version[, result]; do_depwarns=false,
-        time_limit=60*45)
-
-Run all tests for all packages in the given package dependency graph using `ninstances`
-workers and the specified version of Julia. An existing result `Dict` can be specified,
-in which case the function will write to that.
-
-If the keyword argument `do_depwarns` is `true`, deprecation warnings emitted in package
-tests will cause the package's tests to fail, i.e. Julia is run with `--depwarn=error`.
-
-Tests will be forcibly interrupted after `time_limit` seconds.
-"""
-function run(pkgs::Vector, ninstances::Integer, ver::VersionNumber, result=Dict{String,Symbol}();
-             do_depwarns=false, time_limit=60*45)
-    obtain_julia(ver)
+function run(julia::VersionNumber, pkgs::Vector; ninstances::Integer=Sys.CPU_THREADS,
+             result=Dict{String,Symbol}(), kwargs...)
+    obtain_julia(julia)
 
     # In case we need to provide sudo password, do that before starting the actual testing
-    run_sandboxed_julia(`-e '1'`; ver=ver)
+    run_sandboxed_julia(julia, `-e '1'`)
 
     pkgs = copy(pkgs)
     npkgs = length(pkgs)
@@ -235,7 +220,7 @@ function run(pkgs::Vector, ninstances::Integer, ver::VersionNumber, result=Dict{
                         else
                             running[i] = Symbol(pkg.name)
                             times[i] = now()
-                            killed, succeeded = NewPkgEval.run_sandboxed_test(pkg.name; ver=ver, time_limit=time_limit)
+                            killed, succeeded = NewPkgEval.run_sandboxed_test(julia, pkg.name; kwargs...)
                             result[pkg.name] = killed ? :killed :
                                                succeeded ? :ok : :fail
                             running[i] = nothing
@@ -252,4 +237,20 @@ function run(pkgs::Vector, ninstances::Integer, ver::VersionNumber, result=Dict{
         e isa InterruptException || rethrow(e)
     end
     return result
+end
+
+"""
+    run(julia::VersionNumber, pkgnames=nothing; registry=General, update_registry=true, kwargs...)
+
+Run all tests for all packages in the registry `registry`, or only for the packages as
+identified by their name in `pkgnames`, using Julia version `julia` on `ninstances` workers.
+By default, the registry will be first updated unless `update_registry` is set to false.
+
+Refer to `run_sandboxed_test`[@ref] for other possible keyword arguments.
+"""
+function run(julia::VersionNumber=Base.VERSION, pkgnames::Union{Nothing, Vector{String}}=nothing;
+             registry::String=DEFAULT_REGISTRY, update_registry::Bool=true, kwargs...)
+    get_registry(registry; update=update_registry)
+    pkgs = read_pkgs(pkgnames)
+    run(julia, pkgs; kwargs...)
 end

--- a/src/run.jl
+++ b/src/run.jl
@@ -249,8 +249,12 @@ function run(julia::VersionNumber, pkgs::Vector; ninstances::Integer=Sys.CPU_THR
                                     reason = :untestable
                                 elseif occursin("cannot open shared object file: No such file or directory", log)
                                     reason = :binary_dependency
+                                elseif occursin(r"Package .+ does not have .+ in its dependencies", log)
+                                    reason = :missing_dependency
                                 elseif occursin("Some tests did not pass", log)
                                     reason = :test_failures
+                                elseif occursin("ERROR: LoadError: syntax", log)
+                                    reason = :syntax
                                 else
                                     reason = :unknown
                                 end

--- a/src/run.jl
+++ b/src/run.jl
@@ -15,7 +15,7 @@ argument `ver` specifies the version of Julia to use, and `do_obtain` dictates w
 the specified version should first be downloaded. If `do_obtain` is `false`, it must
 already be installed.
 """
-function run_sandboxed_julia(args=``; ver::String, do_obtain=true,
+function run_sandboxed_julia(args=``; ver::VersionNumber, do_obtain=true,
                              stdin=stdin, stdout=stdout, stderr=stderr)
     runner, cmd = runner_sandboxed_julia(args; ver=ver, do_obtain=do_obtain)
     with_mounted_shards(runner) do
@@ -23,7 +23,7 @@ function run_sandboxed_julia(args=``; ver::String, do_obtain=true,
     end
 end
 
-function runner_sandboxed_julia(args=``; ver::String, do_obtain=true)
+function runner_sandboxed_julia(args=``; ver::VersionNumber, do_obtain=true)
     if do_obtain
         obtain_julia(ver)
     else
@@ -55,7 +55,7 @@ seconds or if the log becomes larger than `log_limit`.
 A log for the tests is written to a version-specific directory in the NewPkgEval root
 directory.
 """
-function run_sandboxed_test(pkg::String; ver::String, log_limit = 5*1024^2 #= 5 MB =#,
+function run_sandboxed_test(pkg::String; ver::VersionNumber, log_limit = 5*1024^2 #= 5 MB =#,
                             time_limit = 45*60, do_depwarns=false, kwargs...)
     mkpath(log_path(ver))
     arg = """
@@ -134,7 +134,7 @@ tests will cause the package's tests to fail, i.e. Julia is run with `--depwarn=
 
 Tests will be forcibly interrupted after `time_limit` seconds.
 """
-function run(pkgs::Vector, ninstances::Integer, ver::String, result=Dict{String,Symbol}();
+function run(pkgs::Vector, ninstances::Integer, ver::VersionNumber, result=Dict{String,Symbol}();
              do_depwarns=false, time_limit=60*45)
     obtain_julia(ver)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,13 +4,20 @@ using Test
 # determine the version to use
 const ref = get(ENV, "JULIA_VERSION", string(VERSION))
 const ver = try
-    # maybe it refers to a version in Versions.toml
-    NewPkgEval.obtain_julia(ref)
-    ref
+    # maybe it already refers to a version in Versions.toml
+    v = VersionNumber(ref)
+    NewPkgEval.obtain_julia(v)
+    v
 catch
-    # assume it points to something in our Git repository
-    NewPkgEval.build_julia(ref)
+    # maybe it points to a build in Builds.jl
+    try
+        NewPkgEval.download_julia(ref)
+    catch
+        # assume it points to something in our Git repository
+        NewPkgEval.build_julia(ref)
+    end
 end
+NewPkgEval.obtain_julia(ver::VersionNumber)
 
 @testset "sandbox" begin
     mktemp() do path, io

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,6 +19,10 @@ catch
 end
 NewPkgEval.obtain_julia(ver::VersionNumber)
 
+@testset "registry" begin
+    NewPkgEval.get_registry(update=true)
+end
+
 @testset "sandbox" begin
     mktemp() do path, io
         NewPkgEval.run_sandboxed_julia(`-e 'print(1337)'`; ver=ver, stdout=io)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,7 +30,7 @@ NewPkgEval.obtain_julia(julia::VersionNumber)
     NewPkgEval.run_sandboxed_julia(julia, `-e 'using InteractiveUtils; versioninfo()'`)
 end
 
-const pkgnames = ["JSON", "TimerOutputs", "Crayons", "Example"]
+const pkgnames = ["TimerOutputs", "Crayons", "Example"]
 
 @testset "low-level interface" begin
     pkgs = NewPkgEval.read_pkgs(pkgnames)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,50 +2,51 @@ using NewPkgEval
 using Test
 
 # determine the version to use
-const ref = get(ENV, "JULIA_VERSION", string(VERSION))
-const ver = try
+const version = get(ENV, "JULIA_VERSION", string(VERSION))
+const julia = try
     # maybe it already refers to a version in Versions.toml
-    v = VersionNumber(ref)
+    v = VersionNumber(version)
     NewPkgEval.obtain_julia(v)
     v
 catch
     # maybe it points to a build in Builds.jl
     try
-        NewPkgEval.download_julia(ref)
+        NewPkgEval.download_julia(version)
     catch
         # assume it points to something in our Git repository
-        NewPkgEval.build_julia(ref)
+        NewPkgEval.build_julia(version)
     end
 end
-NewPkgEval.obtain_julia(ver::VersionNumber)
-
-@testset "registry" begin
-    NewPkgEval.get_registry(update=true)
-end
+NewPkgEval.obtain_julia(julia::VersionNumber)
 
 @testset "sandbox" begin
     mktemp() do path, io
-        NewPkgEval.run_sandboxed_julia(`-e 'print(1337)'`; ver=ver, stdout=io)
+        NewPkgEval.run_sandboxed_julia(julia, `-e 'print(1337)'`; stdout=io)
         close(io)
         @test read(path, String) == "1337"
     end
 
-    NewPkgEval.run_sandboxed_julia(`-e 'using InteractiveUtils; versioninfo()'`; ver=ver)
+    # print versioninfo so we can verify in CI logs that the correct version is used
+    NewPkgEval.run_sandboxed_julia(julia, `-e 'using InteractiveUtils; versioninfo()'`)
 end
 
-@testset "PkgEval" begin
-    pkgnames = ["JSON", "TimerOutputs", "Crayons", "Example"]
+const pkgnames = ["JSON", "TimerOutputs", "Crayons", "Example"]
+
+@testset "low-level interface" begin
     pkgs = NewPkgEval.read_pkgs(pkgnames)
 
-    results = NewPkgEval.run(pkgs, 2, ver; time_limit = 0.1)
+    # timeouts
+    results = NewPkgEval.run(julia, pkgs; time_limit = 0.1)
     for pkg in pkgnames
         @test results[pkg] == :killed
     end
+end
 
-    results = NewPkgEval.run(pkgs, 2, ver)
+@testset "main entrypoint" begin
+    results = NewPkgEval.run(julia, pkgnames)
     for pkg in pkgnames
         @test results[pkg] == :ok
-        output = read(joinpath(NewPkgEval.log_path(ver), "$pkg.log"), String)
+        output = read(joinpath(NewPkgEval.log_path(julia), "$pkg.log"), String)
         @test occursin("Testing $pkg tests passed", output)
     end
 end


### PR DESCRIPTION
The goal would be for some cron-job to just target `1.3-latest` and have it work as expected (similar to how `build_julia` currently checks out and returns a version number, but minus the building).