### PR TITLE
Use Docker for sandboxing

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -15,8 +15,8 @@ version = "0.2.0"
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
 [[BinaryBuilder]]
-deps = ["Base64", "GitHub", "HTTP", "InteractiveUtils", "JLD2", "JSON", "LibGit2", "Libdl", "MbedTLS", "ObjectFile", "Pkg", "PkgLicenses", "ProgressMeter", "REPL", "Random", "Registrator", "SHA", "Sockets", "Test", "VT100"]
-git-tree-sha1 = "1bb7c056a24cd0fae318e809f49fc7101a60c123"
+deps = ["Base64", "GitHub", "HTTP", "InteractiveUtils", "JLD2", "JSON", "LibGit2", "Libdl", "MbedTLS", "ObjectFile", "Pkg", "PkgLicenses", "ProgressMeter", "REPL", "Random", "Registrator", "SHA", "Sockets", "Test", "VT100", "ghr_jll"]
+git-tree-sha1 = "1ee9f216521583cc69bb82238ec49ee1913699d1"
 repo-rev = "master"
 repo-url = "https://github.com/JuliaPackaging/BinaryBuilder.jl.git"
 uuid = "12aac903-9f7c-5d81-afc2-d9565ea332ae"
@@ -65,9 +65,9 @@ version = "0.19.4"
 
 [[DataStructures]]
 deps = ["InteractiveUtils", "OrderedCollections"]
-git-tree-sha1 = "1fe8fad5fc84686dcbc674aa255bc867a64f8132"
+git-tree-sha1 = "a1b652fb77ae8ca7ea328fa7ba5aa151036e5c10"
 uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-version = "0.17.5"
+version = "0.17.6"
 
 [[DataValueInterfaces]]
 git-tree-sha1 = "bfc1187b79289637fa0ef6d4436ebdfe6905cbd6"
@@ -289,9 +289,9 @@ version = "0.2.0"
 
 [[Registrator]]
 deps = ["AutoHashEquals", "Base64", "Dates", "Distributed", "FileWatching", "GitForge", "GitHub", "HTTP", "JSON", "LibGit2", "Logging", "MbedTLS", "Mustache", "Mux", "Pkg", "RegistryTools", "Serialization", "Sockets", "TimeToLive", "UUIDs", "ZMQ"]
-git-tree-sha1 = "0776e72422365c3cf00f2e9933b47f7ad8de2a5c"
+git-tree-sha1 = "722d249d1f29be9281dafd14bdf1dd5cb25cf225"
 uuid = "4418983a-e44d-11e8-3aec-9789530b3b3e"
-version = "1.0.1"
+version = "1.1.0"
 
 [[RegistryTools]]
 deps = ["AutoHashEquals", "LibGit2", "Pkg", "UUIDs"]
@@ -396,3 +396,9 @@ deps = ["BinaryProvider", "FileWatching", "Libdl", "Sockets", "Test"]
 git-tree-sha1 = "34e7ac2d1d59d19d0e86bde99f1f02262bfa1613"
 uuid = "c2297ded-f4af-51ae-bb23-16f91089e4e1"
 version = "1.0.0"
+
+[[ghr_jll]]
+deps = ["Libdl", "Pkg"]
+git-tree-sha1 = "a842af97ca0010aedcfd765a4dfcfe403732a929"
+uuid = "07c12ed4-43bc-5495-8a2a-d5838ef8d533"
+version = "0.13.0+0"

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -152,9 +152,9 @@ version = "1.0.0"
 
 [[JLD2]]
 deps = ["CodecZlib", "DataStructures", "FileIO", "Mmap", "Pkg", "Printf", "UUIDs"]
-git-tree-sha1 = "4fc5779f938c5754c6361c131704ab3d910377f6"
+git-tree-sha1 = "bce3df72340c8e03607b118028de22f3e3104f5d"
 uuid = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
-version = "0.1.7"
+version = "0.1.8"
 
 [[JSON]]
 deps = ["Dates", "Mmap", "Parsers", "Unicode"]
@@ -238,9 +238,9 @@ version = "1.1.0"
 
 [[Parsers]]
 deps = ["Dates", "Test"]
-git-tree-sha1 = "a23968e107c0544aca91bfab6f7dd34de1206a54"
+git-tree-sha1 = "0139ba59ce9bc680e2925aec5b7db79065d60556"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "0.3.9"
+version = "0.3.10"
 
 [[Pidfile]]
 deps = ["FileWatching", "Test"]
@@ -288,9 +288,15 @@ uuid = "189a3867-3050-52da-a836-e630ba90ab69"
 version = "0.2.0"
 
 [[Registrator]]
-deps = ["AutoHashEquals", "Base64", "Dates", "Distributed", "FileWatching", "GitForge", "GitHub", "HTTP", "JSON", "LibGit2", "Logging", "MbedTLS", "Mustache", "Mux", "Pkg", "Serialization", "Sockets", "TimeToLive", "UUIDs", "ZMQ"]
-git-tree-sha1 = "0dc917d3370553aebe50b80bdff9142e665a021c"
+deps = ["AutoHashEquals", "Base64", "Dates", "Distributed", "FileWatching", "GitForge", "GitHub", "HTTP", "JSON", "LibGit2", "Logging", "MbedTLS", "Mustache", "Mux", "Pkg", "RegistryTools", "Serialization", "Sockets", "TimeToLive", "UUIDs", "ZMQ"]
+git-tree-sha1 = "0776e72422365c3cf00f2e9933b47f7ad8de2a5c"
 uuid = "4418983a-e44d-11e8-3aec-9789530b3b3e"
+version = "1.0.1"
+
+[[RegistryTools]]
+deps = ["AutoHashEquals", "LibGit2", "Pkg", "UUIDs"]
+git-tree-sha1 = "a3b6433e9ae527443cdec10ea868d3b98a463c23"
+uuid = "d1eb7eb1-105f-429d-abf5-b0f65cb9e2c4"
 version = "1.0.0"
 
 [[SHA]]

--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
 SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 SQLite = "0aa819cd-b072-5ff4-a722-6bc24af294d9"
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
-# NewPkgEval - Evaluate julia packages
+# NewPkgEval.jl
 
-# Basic usage
+*Evaluate Julia packages.*
+
+## Basic usage
+
 In order to run PkgEval against a Julia package do the following:
-
 
 1. Obtain NewPkgEval and install dependencies
 
@@ -11,7 +13,6 @@ In order to run PkgEval against a Julia package do the following:
     cd NewPkgEval.jl
     julia --project 'import Pkg; Pkg.instantiate()'
     ```
-
 
 2. Obtain a binary Julia distribution
 
@@ -57,9 +58,8 @@ In order to run PkgEval against a Julia package do the following:
 
     restart Julia and try again.
 
-    If something goes wrong, or you built julia yourself, you may have to add that stanza
-    manually and copy the tarball from the products/ directory into `deps/downloads`.
-
+    If something goes wrong, or you built Julia yourself, you may have to add that stanza
+    manually and copy the tarball into the `deps/downloads` directory.
 
 3. Try the Julia sandbox environment
 
@@ -70,8 +70,7 @@ In order to run PkgEval against a Julia package do the following:
     hello
     ```
 
-    which will execute the julia command in the sandbox environment of the newly built julia.
-
+    which will execute the Julia command in the sandbox environment of the newly built Julia.
 
 4. Run PkgEval
 
@@ -81,9 +80,3 @@ In order to run PkgEval against a Julia package do the following:
     ```
 
     See the docstrings for more arguments.
-
-    If you have problem running more than 1 worker at a time try set the environment variable
-
-    ```
-    BINARYBUILDER_USE_SQUASHFS=false
-    ```

--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ In order to run PkgEval against a Julia package do the following:
 
     You have three choices. Either you use a specific version of Julia that has been
     registered in `Versions.toml` already, and will automatically be downloaded, verified
-    and unpacked when required using the `obtain_julia` function:
+    and unpacked when required using the `prepare_julia` function:
 
     ```jl
     import NewPkgEval
-    NewPkgEval.obtain_julia(v"1.2.0")
+    NewPkgEval.prepare_julia(v"1.2.0")
     ```
 
     If you want to use an unreleased version of Julia as provided by the build bots, you can

--- a/bin/test.jl
+++ b/bin/test.jl
@@ -2,6 +2,7 @@
 
 using DataFrames
 using NewPkgEval
+using Random
 using SQLite
 using Dates
 
@@ -57,7 +58,8 @@ function main(;pkgnames=["Example"], julia_releases=["1.2"], registry="General",
                                                     log, now(), elapsed]))
         end
 
-        NewPkgEval.run(julia_version, pkgs; callback=store_result)
+        # use a random test order to (hopefully) get a more reasonable ETA
+        NewPkgEval.run(julia_version, shuffle(pkgs); callback=store_result)
     end
 
     return

--- a/bin/test.jl
+++ b/bin/test.jl
@@ -18,7 +18,7 @@ function main(;pkgnames=["Example"], julia_releases=["1.2"], registry="General",
                           for julia_release in julia_releases)
 
     # get the packages
-    NewPkgEval.get_registry(update=true)
+    NewPkgEval.prepare_registry(update=true)
     pkgs = NewPkgEval.read_pkgs(pkgnames)
 
     # prepare the database

--- a/bin/test.jl
+++ b/bin/test.jl
@@ -16,10 +16,13 @@ function main(;pkgnames=["Example"], julia_releases=["1.2"], registry="General",
     # get the Julia versions
     julia_versions = Dict(julia_release => NewPkgEval.download_julia(julia_release)
                           for julia_release in julia_releases)
+    NewPkgEval.prepare_julia.(values(julia_versions))
 
     # get the packages
     NewPkgEval.prepare_registry(update=true)
     pkgs = NewPkgEval.read_pkgs(pkgnames)
+
+    NewPkgEval.prepare_runner()
 
     # prepare the database
     SQLite.execute!(db, """

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -1,0 +1,9 @@
+FROM ubuntu:latest
+
+RUN apt-get update && apt-get install -y \
+    # download engines
+    curl \
+    # PyCall.jl
+    python3 libpython3.6 python3-distutils virtualenv \
+    # clean-up
+    && rm -rf /var/lib/apt/lists/*

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -1,9 +1,19 @@
 FROM ubuntu:latest
 
+ENV DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update && apt-get install -y \
     # download engines
     curl \
+    # essential tools
+    git unzip \
+    # toolchain
+    build-essential gfortran \
     # PyCall.jl
     python3 libpython3.6 python3-distutils virtualenv \
+    # TimeZones.jl
+    tzdata \
+    # FFMPEG.jl
+    ffmpeg \
     # clean-up
     && rm -rf /var/lib/apt/lists/*

--- a/src/NewPkgEval.jl
+++ b/src/NewPkgEval.jl
@@ -1,9 +1,8 @@
 module NewPkgEval
 
-using BinaryBuilder
 import Pkg.TOML
 using Pkg
-import Base: UUID
+using Base: UUID
 using Dates
 
 downloads_dir(name) = joinpath(@__DIR__, "..", "deps", "downloads", name)

--- a/src/julia.jl
+++ b/src/julia.jl
@@ -20,11 +20,11 @@ function installed_julia_dir(ver)
 end
 
 """
-    obtain_julia(the_ver)
+    prepare_julia(the_ver)
 
 Download the specified version of Julia using the information provided in `Versions.toml`.
 """
-function obtain_julia(the_ver::VersionNumber)
+function prepare_julia(the_ver::VersionNumber)
     vers = read_versions()
     for (ver, data) in vers
         ver == string(the_ver) || continue
@@ -91,14 +91,14 @@ function download_julia(name::String)
         commit_short = read(`$(installed_julia_dir(base))/bin/julia -e 'print(Base.GIT_VERSION_INFO.commit_short)'`, String)
         version = VersionNumber(string(version) * string("-", commit_short))
     end
-    rm(temp_dir; recursive=true) # let `obtain_julia` unpack; keeps code simpler here
+    rm(temp_dir; recursive=true) # let `prepare_julia` unpack; keeps code simpler here
 
     versions = read_versions()
     if haskey(versions, string(version))
         @info "Julia $name (version $version) already available"
         rm(temp_file)
     else
-        # always use the hash of the downloaded file to force a check during `obtain_julia`
+        # always use the hash of the downloaded file to force a check during `prepare_julia`
         hash = filehash(temp_file)
 
         # move to its final location

--- a/src/julia.jl
+++ b/src/julia.jl
@@ -1,3 +1,4 @@
+using BinaryBuilder
 using LibGit2
 import SHA: sha256
 

--- a/src/registry.jl
+++ b/src/registry.jl
@@ -4,12 +4,12 @@ const DEFAULT_REGISTRY = "General"
 const skip_lists = Dict{String,Vector{String}}()
 
 """
-    get_registry([name]; update=false)
+    prepare_registry([name]; update=false)
 
 Download the given registry, or if it already exists, update it if `update` is true.
 `name` must correspond to an existing stanza in the `deps/Registries.toml` file.
 """
-function get_registry(name=DEFAULT_REGISTRY; update=false)
+function prepare_registry(name=DEFAULT_REGISTRY; update=false)
     reg = read_registries()[name]
     regspec = RegistrySpec(name = name, url = reg["url"], uuid = UUID(reg["uuid"]))
 
@@ -35,7 +35,7 @@ package name and registry, its UUID, and a path to it. If `pkgs` is given, only 
 packages matching the names in `pkgs`
 """
 function read_pkgs(pkgs::Union{Nothing, Vector{String}}=nothing; registry=DEFAULT_REGISTRY)
-    get_registry(registry)
+    prepare_registry(registry)
     if pkgs !== nothing
         pkgs = copy(pkgs)
     end

--- a/src/run.jl
+++ b/src/run.jl
@@ -34,7 +34,7 @@ function runner_sandboxed_julia(julia::VersionNumber, args=``; interactive=true)
         cmd = `$cmd --interactive --tty`
     end
 
-    `$cmd --rm newpkgeval /maps/julia/bin/julia --color=yes $args`
+    `$cmd --rm newpkgeval /maps/julia/bin/julia $args`
 end
 
 """

--- a/src/run.jl
+++ b/src/run.jl
@@ -169,16 +169,21 @@ function run(julia::VersionNumber, pkgs::Vector; ninstances::Integer=Sys.CPU_THR
             println(io, "\tRemaining: ", x)
             for i = 1:ninstances
                 r = running[i]
-                if r === nothing
-                    println(io, "Worker $i: -------")
+                str = if r === nothing
+                    " $i: -------"
                 else
-                    println(io, "Worker $i: $(r) $(runtimestr(times[i]))")
+                    " $i: $(r) $(runtimestr(times[i]))"
+                end
+                if i%2 == 1 && i < ninstances
+                    print(io, rpad(str, 45))
+                else
+                    println(io, str)
                 end
             end
             print(String(take!(io.io)))
             sleep(1)
             CSI = "\e["
-            print(io, "$(CSI)$(ninstances+1)A$(CSI)1G$(CSI)0J")
+            print(io, "$(CSI)$(ceil(Int, ninstances/2)+1)A$(CSI)1G$(CSI)0J")
         end
     end
 

--- a/src/run.jl
+++ b/src/run.jl
@@ -137,7 +137,7 @@ function run(julia::VersionNumber, pkgs::Vector; ninstances::Integer=Sys.CPU_THR
     start = now()
     io = IOContext(IOBuffer(), :color=>true)
     on_ci = parse(Bool, get(ENV, "CI", "false"))
-    p = Progress(npkgs; barlen=50)
+    p = Progress(npkgs; barlen=50, color=:normal)
     function update_output()
         # known statuses
         o = count(==(:ok),      values(result))
@@ -152,7 +152,8 @@ function run(julia::VersionNumber, pkgs::Vector; ninstances::Integer=Sys.CPU_THR
             if isempty(time.periods) || first(time.periods) isa Millisecond
                 "just started"
             else
-                "running for $time"
+                # be coarse in the name of brevity
+                string(first(time.periods))
             end
         end
 
@@ -172,9 +173,9 @@ function run(julia::VersionNumber, pkgs::Vector; ninstances::Integer=Sys.CPU_THR
             for i = 1:ninstances
                 r = running[i]
                 str = if r === nothing
-                    " $i: -------"
+                    " #$i: -------"
                 else
-                    " $i: $(r) $(runtimestr(times[i]))"
+                    " #$i: $r ($(runtimestr(times[i])))"
                 end
                 if i%2 == 1 && i < ninstances
                     print(io, rpad(str, 45))
@@ -199,6 +200,7 @@ function run(julia::VersionNumber, pkgs::Vector; ninstances::Integer=Sys.CPU_THR
                 while (!isempty(pkgs) || !all(==(nothing), running)) && !done
                     update_output()
                 end
+                println()
                 stop_work()
             catch e
                 stop_work()

--- a/src/run.jl
+++ b/src/run.jl
@@ -10,7 +10,7 @@ end
 
 Run Julia inside of a sandbox, passing the given arguments `args` to it. The argument
 `julia` specifies the version of Julia to use, which should be readily available (i.e. the
-user is responsible for having called `obtain_julia`).
+user is responsible for having called `prepare_julia`).
 """
 function run_sandboxed_julia(julia::VersionNumber, args=``; stdin=stdin, stdout=stdout,
                              stderr=stderr, kwargs...)
@@ -104,7 +104,7 @@ end
 
 function run(julia::VersionNumber, pkgs::Vector; ninstances::Integer=Sys.CPU_THREADS,
              callback=nothing, kwargs...)
-    obtain_julia(julia)
+    prepare_julia(julia)
 
     length(readlines(`docker images -q newpkgeval`)) == 0 && error("Docker image not found, please run NewPkgEval.prepare_runner() first.")
 
@@ -275,7 +275,7 @@ Refer to `run_sandboxed_test`[@ref] for other possible keyword arguments.
 """
 function run(julia::VersionNumber=Base.VERSION, pkgnames::Union{Nothing, Vector{String}}=nothing;
              registry::String=DEFAULT_REGISTRY, update_registry::Bool=true, kwargs...)
-    get_registry(registry; update=update_registry)
+    prepare_registry(registry; update=update_registry)
     prepare_runner()
     pkgs = read_pkgs(pkgnames)
     run(julia, pkgs; kwargs...)

--- a/src/run.jl
+++ b/src/run.jl
@@ -138,11 +138,11 @@ function run(julia::VersionNumber, pkgs::Vector; ninstances::Integer=Sys.CPU_THR
     function update_output()
         # known statuses
         o = count(==(:ok),      values(result))
+        s = count(==(:skip),    values(result))
         f = count(==(:fail),    values(result))
         k = count(==(:killed),  values(result))
-        s = count(==(:skipped), values(result))
         # remaining
-        x = npkgs - (o + f + s)
+        x = npkgs - length(result)
 
         function runtimestr(start)
             time = Dates.canonicalize(Dates.CompoundPeriod(now() - start))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,6 +20,7 @@ end
 NewPkgEval.prepare_julia(julia::VersionNumber)
 
 @testset "sandbox" begin
+    NewPkgEval.prepare_runner()
     mktemp() do path, io
         NewPkgEval.run_sandboxed_julia(julia, `-e 'print(1337)'`; stdout=io)
         close(io)
@@ -33,9 +34,7 @@ end
 const pkgnames = ["TimerOutputs", "Crayons", "Example"]
 
 @testset "low-level interface" begin
-    NewPkgEval.prepare_julia(julia)
     NewPkgEval.prepare_registry()
-    NewPkgEval.prepare_runner()
 
     pkgs = NewPkgEval.read_pkgs(pkgnames)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,7 +6,7 @@ const version = get(ENV, "JULIA_VERSION", string(VERSION))
 const julia = try
     # maybe it already refers to a version in Versions.toml
     v = VersionNumber(version)
-    NewPkgEval.obtain_julia(v)
+    NewPkgEval.prepare_julia(v)
     v
 catch
     # maybe it points to a build in Builds.jl
@@ -17,7 +17,7 @@ catch
         NewPkgEval.build_julia(version)
     end
 end
-NewPkgEval.obtain_julia(julia::VersionNumber)
+NewPkgEval.prepare_julia(julia::VersionNumber)
 
 @testset "sandbox" begin
     mktemp() do path, io
@@ -33,6 +33,10 @@ end
 const pkgnames = ["TimerOutputs", "Crayons", "Example"]
 
 @testset "low-level interface" begin
+    NewPkgEval.prepare_julia(julia)
+    NewPkgEval.prepare_registry()
+    NewPkgEval.prepare_runner()
+
     pkgs = NewPkgEval.read_pkgs(pkgnames)
 
     # timeouts


### PR DESCRIPTION
Although BB's UserNS sandbox is nice, being Alpine (musl) based gives issues with several packages. Furthermore, with Docker it's much easier to use, e.g., GPUs, and install whatever dependencies packages require.

Also fixes https://github.com/JuliaComputing/NewPkgEval.jl/issues/16