### PR TITLE
Support for retrying packages.

### DIFF
--- a/deps/Registries.toml
+++ b/deps/Registries.toml
@@ -11,4 +11,8 @@ retry = [
     "SpatialJackknife",
     "StatsModels",
     "UncertainData",
+    "StressTest",
+    "StateSpaceReconstruction",
+    "PolyChaos",
+    "RoME",
 ]

--- a/deps/Registries.toml
+++ b/deps/Registries.toml
@@ -2,5 +2,13 @@
 url = "https://github.com/JuliaRegistries/General.git"
 uuid = "23338594-aafe-5451-b93e-139f81909106"
 skip = [
-    "julia", # really crappy software
+    "julia",
+]
+retry = [
+    "EcologicalNetworks",
+    "FixedEffectModels",
+    "GLM",
+    "SpatialJackknife",
+    "StatsModels",
+    "UncertainData",
 ]

--- a/src/registry.jl
+++ b/src/registry.jl
@@ -1,7 +1,7 @@
 const DEFAULT_REGISTRY = "General"
 
-# Skip these packages when testing packages
 const skip_lists = Dict{String,Vector{String}}()
+const retry_lists = Dict{String,Vector{String}}()
 
 """
     prepare_registry([name])
@@ -22,6 +22,7 @@ function prepare_registry(name=DEFAULT_REGISTRY; update::Bool=false)
 
     # read some metadata
     skip_lists[name] = get(reg, "skip", String[])
+    retry_lists[name] = get(reg, "retry", String[])
 
     return
 end


### PR DESCRIPTION
Fixes https://github.com/JuliaComputing/NewPkgEval.jl/issues/40

I decided only to retry packages with test failures, even though the most recent daily has a couple of other packages that regularly fail but with much more serious error (e.g. segmentation faults). I don't think we should retry and hide those.