### PR TITLE
Install texlive in the Docker image

### DIFF
--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -23,6 +23,16 @@ RUN apt-get update && apt-get install -y \
     default-jre-headless \
     # RCall.jl
     r-base \
+    # PGFPlotsX.jl, PredictMD.jl
+    gnuplot \
+    pdf2svg \
+    poppler-utils \
+    texlive \
+    texlive-binaries \
+    texlive-latex-base \
+    texlive-latex-extra \
+    texlive-luatex \
+    texlive-pictures \
     # clean-up
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Fixes #47 

This is necessary for the test suites of the following packages:
- PGFPlotsX.jl
- PredictMD.jl