### PR TITLE
Set the environment variable "JULIA_PKGEVAL" to "true"

### DIFF
--- a/src/run.jl
+++ b/src/run.jl
@@ -111,6 +111,7 @@ function run_sandboxed_test(julia::VersionNumber, pkg; log_limit = 2^20 #= 1 MB 
 
         ENV["CI"] = true
         ENV["PKGEVAL"] = true
+        ENV["JULIAPKGEVAL"] = true
 
         Pkg.add(ARGS...)
         Pkg.test(ARGS...)

--- a/src/run.jl
+++ b/src/run.jl
@@ -111,7 +111,7 @@ function run_sandboxed_test(julia::VersionNumber, pkg; log_limit = 2^20 #= 1 MB 
 
         ENV["CI"] = true
         ENV["PKGEVAL"] = true
-        ENV["JULIAPKGEVAL"] = true
+        ENV["JULIA_PKGEVAL"] = true
 
         Pkg.add(ARGS...)
         Pkg.test(ARGS...)


### PR DESCRIPTION
Currently, we set the `CI` and `PKGEVAL` environment variables.

It has occured to me that neither of these are Julia-specific. `CI` is certainly a common environment variable, and I suppose that there could be other pieces of software named `PKGEVAL`.

I think it would be really nice for NewPkgEval to also set an environment variable that is unambiguously specific to the Julia package evaluation infrastructure. So this PR sets the "JULIA_PKGEVAL" to "true".