### PR TITLE
Add compat entry for Julia

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,6 +16,7 @@ SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 
 [compat]
 DataFrames = "0.19"
+julia = "1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
This pull request adds the following `[compat]` entry to the `Project.toml` file:
```toml
julia = "1"
```

This is consistent with the advice that we give to package authors.