### PR TITLE
Run Julia under `xvfb-run`

### DIFF
--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -3,6 +3,8 @@ FROM ubuntu:latest
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -y \
+    # container tools
+    dumb-init \
     # download engines
     curl \
     # essential tools
@@ -42,3 +44,5 @@ RUN useradd --create-home --shell /bin/bash --groups sudo pkgeval && \
     echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 WORKDIR /home/pkgeval
 USER pkgeval
+
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -33,6 +33,8 @@ RUN apt-get update && apt-get install -y \
     texlive-latex-extra \
     texlive-luatex \
     texlive-pictures \
+    # Any package that needs a display (e.g. Gtk.jl)
+    xvfb \
     # clean-up
     && rm -rf /var/lib/apt/lists/*
 

--- a/src/run.jl
+++ b/src/run.jl
@@ -46,7 +46,7 @@ function spawn_sandboxed_julia(julia::VersionNumber, args=``; interactive=true, 
         cmd = `$cmd --name $name`
     end
 
-    container = chomp(read(`$cmd --rm newpkgeval /opt/julia/bin/julia $args`, String))
+    container = chomp(read(`$cmd --rm newpkgeval xvfb-run /opt/julia/bin/julia $args`, String))
     return something(name, container)
 end
 


### PR DESCRIPTION
This PR runs Julia under `xvfb-run`. This should fix all of the packages that are failing because they need a display. One example of such a package is Gtk.jl (example log [here](https://github.com/maleadt/BasePkgEvalReports/blob/8afa60b4129a965cd82085b3c454854b11619a0e/pkgeval-daily_2019_12_30/logs/Gtk/1.4.0-DEV-032dbe33e3.log)).