### PR TITLE
Tweaks to Docker environment

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -16,9 +16,9 @@ uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
 [[BinaryBuilder]]
 deps = ["Base64", "Dates", "GitHub", "HTTP", "InteractiveUtils", "JLD2", "JSON", "LibGit2", "Libdl", "MbedTLS", "ObjectFile", "Pkg", "PkgLicenses", "ProgressMeter", "REPL", "Random", "Registrator", "RegistryTools", "SHA", "Sockets", "ghr_jll"]
-git-tree-sha1 = "777ceefb0b33ff663d373a74b28ca048237b985b"
+git-tree-sha1 = "d995cc425ca973880f5913835673c1289a524cdf"
 uuid = "12aac903-9f7c-5d81-afc2-d9565ea332ae"
-version = "0.2.1"
+version = "0.2.2"
 
 [[BinaryProvider]]
 deps = ["Libdl", "SHA"]
@@ -28,9 +28,9 @@ version = "0.5.8"
 
 [[CategoricalArrays]]
 deps = ["Compat", "DataAPI", "Future", "JSON", "Missings", "Printf", "Reexport", "Statistics", "Unicode"]
-git-tree-sha1 = "9127b0c2ee1bfd810921dd688dd8d73be1d9fb57"
+git-tree-sha1 = "7c4419347d724a057b5a550078f8ff4cdfdeedf6"
 uuid = "324d7699-5711-5eae-9e2f-1d82baa6b597"
-version = "0.7.5"
+version = "0.7.6"
 
 [[CodecZlib]]
 deps = ["BinaryProvider", "Libdl", "TranscodingStreams"]
@@ -57,9 +57,9 @@ version = "0.19.4"
 
 [[DataStructures]]
 deps = ["InteractiveUtils", "OrderedCollections"]
-git-tree-sha1 = "a1b652fb77ae8ca7ea328fa7ba5aa151036e5c10"
+git-tree-sha1 = "f784254f428fb8fd7ac15982e5862a38a44523d3"
 uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-version = "0.17.6"
+version = "0.17.7"
 
 [[DataValueInterfaces]]
 git-tree-sha1 = "bfc1187b79289637fa0ef6d4436ebdfe6905cbd6"
@@ -138,9 +138,9 @@ version = "1.0.0"
 
 [[JLD2]]
 deps = ["CodecZlib", "DataStructures", "FileIO", "Mmap", "Pkg", "Printf", "UUIDs"]
-git-tree-sha1 = "2c1a6d672f2b85a520d59e63851bc67226b06ba8"
+git-tree-sha1 = "5deae9f0745ef505ed155a0029629cf08502ccab"
 uuid = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
-version = "0.1.10"
+version = "0.1.11"
 
 [[JSON]]
 deps = ["Dates", "Mmap", "Parsers", "Unicode"]
@@ -205,10 +205,10 @@ uuid = "ffc61752-8dc7-55ee-8c37-f3e9cdd09e70"
 version = "0.5.13"
 
 [[Mux]]
-deps = ["AssetRegistry", "Base64", "HTTP", "Hiccup", "Lazy", "Pkg", "Sockets", "Test", "WebSockets"]
-git-tree-sha1 = "5b41f03d63400c290bab4e1a49fb9ac36de1084a"
+deps = ["AssetRegistry", "Base64", "HTTP", "Hiccup", "Lazy", "Pkg", "Sockets", "WebSockets"]
+git-tree-sha1 = "3621676e7f711aca14d783d1bff9ac379d9df6b7"
 uuid = "a975b10e-0019-58db-a62f-e48ff68538c9"
-version = "0.7.0"
+version = "0.7.1"
 
 [[ObjectFile]]
 deps = ["Reexport", "StructIO", "Test"]
@@ -235,7 +235,7 @@ uuid = "fa939f87-e72e-5be4-a000-7fc836dbe307"
 version = "1.1.0"
 
 [[Pkg]]
-deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
+deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Test", "UUIDs"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [[PkgLicenses]]
@@ -275,10 +275,10 @@ uuid = "189a3867-3050-52da-a836-e630ba90ab69"
 version = "0.2.0"
 
 [[Registrator]]
-deps = ["AutoHashEquals", "Base64", "Dates", "Distributed", "FileWatching", "GitForge", "GitHub", "HTTP", "JSON", "LibGit2", "Logging", "MbedTLS", "Mustache", "Mux", "Pkg", "RegistryTools", "Serialization", "Sockets", "TimeToLive", "UUIDs", "ZMQ"]
-git-tree-sha1 = "722d249d1f29be9281dafd14bdf1dd5cb25cf225"
+deps = ["AutoHashEquals", "Base64", "Dates", "Distributed", "FileWatching", "GitForge", "GitHub", "HTTP", "JSON", "LibGit2", "Logging", "MbedTLS", "Mustache", "Mux", "Pkg", "Serialization", "Sockets", "TimeToLive", "UUIDs", "ZMQ"]
+git-tree-sha1 = "0dc917d3370553aebe50b80bdff9142e665a021c"
 uuid = "4418983a-e44d-11e8-3aec-9789530b3b3e"
-version = "1.1.0"
+version = "1.0.0"
 
 [[RegistryTools]]
 deps = ["AutoHashEquals", "LibGit2", "Pkg", "UUIDs"]
@@ -336,10 +336,10 @@ deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [[TimeToLive]]
-deps = ["Dates", "Test"]
-git-tree-sha1 = "43defcaf72b89b047f11b778cd83b71ac3e418b0"
+deps = ["Dates"]
+git-tree-sha1 = "1f1389007d16385ec02e497bef6c2caffba99b65"
 uuid = "37f0c46e-897f-50ef-b453-b26c3eed3d6c"
-version = "0.2.0"
+version = "0.3.0"
 
 [[TranscodingStreams]]
 deps = ["Random", "Test"]
@@ -361,10 +361,16 @@ uuid = "104b5d7c-a370-577a-8038-80a2059c5097"
 version = "1.5.2"
 
 [[ZMQ]]
-deps = ["BinaryProvider", "FileWatching", "Libdl", "Sockets", "Test"]
-git-tree-sha1 = "34e7ac2d1d59d19d0e86bde99f1f02262bfa1613"
+deps = ["FileWatching", "Sockets", "ZeroMQ_jll"]
+git-tree-sha1 = "adb2d52aa12c8284da12714f35d2b21fc3d5b2bb"
 uuid = "c2297ded-f4af-51ae-bb23-16f91089e4e1"
-version = "1.0.0"
+version = "1.2.0"
+
+[[ZeroMQ_jll]]
+deps = ["Libdl", "Pkg"]
+git-tree-sha1 = "a22171d073707dbcc99a1dfefc2c6e823beb9664"
+uuid = "8f1865be-045e-5c20-9c9f-bfbfb0764568"
+version = "4.3.1+0"
 
 [[ghr_jll]]
 deps = ["Libdl", "Pkg"]

--- a/Project.toml
+++ b/Project.toml
@@ -15,8 +15,8 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 
 [compat]
-DataFrames = "0.19"
 BinaryBuilder = "0.2.1"
+DataFrames = "0.19"
 julia = "1.3"
 
 [extras]

--- a/src/run.jl
+++ b/src/run.jl
@@ -37,7 +37,8 @@ function spawn_sandboxed_julia(julia::VersionNumber, args=``; interactive=true, 
     cmd = ```$cmd --mount type=bind,source=$installed_julia_path,target=/opt/julia,readonly
                   --mount type=bind,source=$registry_path,target=/usr/local/share/julia/registries,readonly
                   --env JULIA_DEPOT_PATH="::/usr/local/share/julia"
-                  --tmpfs /home/pkgeval:exec,uid=1000,gid=1000```
+                  --tmpfs /home/pkgeval:exec,uid=1000,gid=1000
+                  --cpus=1```
     # FIXME: tmpfs mounts don't copy uid/gid back, so we need to correct this manually
     #        https://github.com/opencontainers/runc/issues/1647
 

--- a/src/run.jl
+++ b/src/run.jl
@@ -25,7 +25,8 @@ function run_sandboxed_julia(julia::VersionNumber, args=``; wait=true,
     Base.run(pipeline(`docker attach $container`, stdin=stdin, stdout=stdout, stderr=stderr); wait=wait)
 end
 
-function spawn_sandboxed_julia(julia::VersionNumber, args=``; interactive=true, name=nothing)
+function spawn_sandboxed_julia(julia::VersionNumber, args=``; interactive=true,
+                               name=nothing, cpus::Integer=2, tmpfs::Bool=true)
     cmd = `docker run --detach`
 
     # mount data
@@ -37,10 +38,17 @@ function spawn_sandboxed_julia(julia::VersionNumber, args=``; interactive=true, 
     cmd = ```$cmd --mount type=bind,source=$installed_julia_path,target=/opt/julia,readonly
                   --mount type=bind,source=$registry_path,target=/usr/local/share/julia/registries,readonly
                   --env JULIA_DEPOT_PATH="::/usr/local/share/julia"
-                  --tmpfs /home/pkgeval:exec,uid=1000,gid=1000
-                  --cpus=1```
-    # FIXME: tmpfs mounts don't copy uid/gid back, so we need to correct this manually
-    #        https://github.com/opencontainers/runc/issues/1647
+          ```
+
+    # mount working directory in tmpfs
+    if tmpfs
+        cmd = `$cmd --tmpfs /home/pkgeval:exec,uid=1000,gid=1000`
+        # FIXME: tmpfs mounts don't copy uid/gid back, so we need to correct this manually
+        #        https://github.com/opencontainers/runc/issues/1647
+    end
+
+    # restrict resource usage
+    cmd = `$cmd --cpus=$cpus --env JULIA_NUM_THREADS=$cpus`
 
     if interactive
         cmd = `$cmd --interactive --tty`

--- a/src/run.jl
+++ b/src/run.jl
@@ -36,7 +36,10 @@ function spawn_sandboxed_julia(julia::VersionNumber, args=``; interactive=true, 
     @assert isdir(registry_path)
     cmd = ```$cmd --mount type=bind,source=$installed_julia_path,target=/opt/julia,readonly
                   --mount type=bind,source=$registry_path,target=/usr/local/share/julia/registries,readonly
-                  --env JULIA_DEPOT_PATH="::/usr/local/share/julia"```
+                  --env JULIA_DEPOT_PATH="::/usr/local/share/julia"
+                  --tmpfs /home/pkgeval:exec,uid=1000,gid=1000```
+    # FIXME: tmpfs mounts don't copy uid/gid back, so we need to correct this manually
+    #        https://github.com/opencontainers/runc/issues/1647
 
     if interactive
         cmd = `$cmd --interactive --tty`


### PR DESCRIPTION
Use tmpfs to cut down on I/O and filesystem load (which might have been causing some issues on arctic). It's mounted `exec`, but still `nosuid,nodev`. I would think no package requires that though.

Also restrict each job to a single CPU, since some tests use everything available and might cause timeouts on other tests.