### PR TITLE
Set `ENV["PYTHON"] = ""` and `ENV["R_HOME"] = "*"`

### DIFF
--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -17,10 +17,6 @@ RUN apt-get update && apt-get install -y \
     git unzip sudo \
     # toolchain
     build-essential gfortran pkg-config \
-    # PyCall.jl
-    python3 libpython3.6 python3-distutils virtualenv \
-    # PyPlot
-    python3-matplotlib \
     # TimeZones.jl
     tzdata \
     # FFMPEG.jl
@@ -29,8 +25,6 @@ RUN apt-get update && apt-get install -y \
     zlib1g-dev \
     # JavaCall.jl
     default-jre-headless \
-    # RCall.jl
-    r-base \
     # PGFPlotsX.jl, PredictMD.jl
     gnuplot \
     pdf2svg \

--- a/src/run.jl
+++ b/src/run.jl
@@ -116,6 +116,9 @@ function run_sandboxed_test(install::String, pkg; log_limit = 2^20 #= 1 MB =#,
         ENV["CI"] = true
         ENV["PKGEVAL"] = true
         ENV["JULIA_PKGEVAL"] = true
+    
+        ENV["PYTHON"] = ""
+        ENV["R_HOME"] = "*"
 
         Pkg.add(ARGS...)
         Pkg.test(ARGS...)


### PR DESCRIPTION
E.g. if you look at the PyCall tests, you'll notice that it uses the system Python, and the tests fail: https://github.com/JuliaCI/NanosoldierReports/blob/master/pkgeval/by_date/2020-08/26/logs/PyCall/1.6.0-DEV-5da96913c2.log

This PR forces Julia to install its own Python and its own R.

cc: @maleadt 