### PR TITLE
Bump package rootfs.

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -22,9 +22,9 @@ lazy = true
     url = "https://github.com/JuliaCI/PkgEval.jl/releases/download/v0.1/debian-bullseye-20220818.tar.xz"
 
 [package_linux]
-git-tree-sha1 = "1f829834cb7dfbfff7068892af39608ff6112c28"
+git-tree-sha1 = "104eaa2e0f648fd5de41697329b544a92f3edabf"
 lazy = true
 
     [[package_linux.download]]
-    sha256 = "39db1a3e1ef8b624daea4e7f3f0355e249043de960e16a1988cb96ed9ef725fc"
-    url = "https://github.com/JuliaCI/rootfs-images/releases/download/v5.30/package_linux.x86_64.tar.gz"
+    sha256 = "20b8706720ae9d1471abc209c704570b7a7596c7d953050ac1f27094fd31bbf2"
+    url = "https://github.com/JuliaCI/rootfs-images/releases/download/v5.31/package_linux.x86_64.tar.gz"


### PR DESCRIPTION
The new version includes patchelf, which makes the contrib/fixup scripts work.
Ref https://github.com/JuliaCI/rootfs-images/pull/218