### PR TITLE
Prevent external stdlibs from being blacklisted

### DIFF
--- a/Packages.toml
+++ b/Packages.toml
@@ -99,6 +99,30 @@ important = [
     "Plots",
     "Revise",
     "PackageCompiler",
+
+    # The following is the list of external stdlibs (excluding JLLs).
+    # An external stdlib is a Julia stdlib that lives in an external repo (not the JuliaLang/julia repo).
+    # Please keep this list up-to-date with https://github.com/JuliaLang/julia/tree/master/stdlib
+    # You know it's an external stdlib if it has a `$name.version` file in that folder
+    #
+    # Motivation: We never want to blacklist external stdlibs, because after https://github.com/JuliaCI/julia-buildkite/pull/483,
+    # PkgEval is the easiest way to test an external stdlib on your PR to JuliaLang/julia.
+    "ArgTools",
+    "DelimitedFiles",
+    "Distributed",
+    "Downloads",
+    "JuliaSyntaxHighlighting",
+    "LazyArtifacts",
+    "LibCURL",
+    "LinearAlgebra",
+    "NetworkOptions",
+    "Pkg",
+    "SHA",
+    "SparseArrays",
+    "Statistics",
+    "StyledStrings",
+    "SuiteSparse",
+    "Tar",
 ]
 
 # packages that are slow, and should be granted more test time (they're worth it)


### PR DESCRIPTION
Needed in order to make PkgEval useful for external stdlibs.

We need PkgEval for external stdlibs because of https://github.com/JuliaCI/julia-buildkite/pull/483.