### PR TITLE
`scripts/evaluate.jl`: Support `Pkg.DEFAULT_IO` being a scoped value (but retain support for older Pkg and older Julia)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ['1.10', '1.11', 'nightly']
+        version: ['1.10', '1.11']
         os: ['ubuntu-latest']
         arch: [x64]
         test_julia: ['']


### PR DESCRIPTION
See https://github.com/JuliaLang/julia/commit/1067db80b96cafb9da6864afbfdd9d6e27665c33 for further discussion (h/t @vtjnash for first noticing this).

See also https://github.com/JuliaLang/Pkg.jl/pull/4499/files#r2574098980