### PR TITLE
Add `--bind` option to `Configuration` for user-provided mounts

### DIFF
--- a/bin/test_package.jl
+++ b/bin/test_package.jl
@@ -5,7 +5,7 @@ function usage(error=nothing)
         println(stderr, "ERROR: $error")
     end
     println(stderr, """
-        Usage: julia test_package.jl [--julia=nightly] [--julia_args=""] [--env=""] [--rr=false]
+        Usage: julia test_package.jl [--julia=nightly] [--julia_args=""] [--env=""] [--bind=""] [--rr=false]
                                      [--name=...] [--version=...] [--rev=...] [--url=...] [--path=...]
 
         This script can be used to quickly test a package against a specific version of Julia.
@@ -16,6 +16,7 @@ function usage(error=nothing)
         The `--julia` flag can be used to specify the version of Julia to test with, and defaults to `nightly`.
         To pass additional arguments to Julia, use one or more `--julia_args` flag.
         Similarly, to set environment variables, use one or more `--env` flag.
+        To bind-mount a host directory into the sandbox, use one or more `--bind=src:dst[:ro|:rw]` flag.
         With the `--rr` flag you can enable running under `rr`.""")
     exit(error === nothing ? 0 : 1)
 end
@@ -42,7 +43,7 @@ end
 
 # create the Configuration object
 config_flags = [(:julia => String), (:julia_args => Vector{String}),
-                (:env => Vector{String}), (:rr => Bool)]
+                (:env => Vector{String}), (:bind => Vector{String}), (:rr => Bool)]
 config_args = Dict()
 function parse_value(typ, val)
     if typ === String

--- a/src/PkgEvalCore.jl
+++ b/src/PkgEvalCore.jl
@@ -76,6 +76,9 @@ Base.@kwdef struct Configuration
     # execution properties
     ## a list of environment variables to set in the sandbox
     env::Setting{Vector{String}} = Default(String[])
+    ## a list of bind-mount specs `src:dst[:ro|:rw]`
+    ##`src` is a host path. `dst` is the path inside the sandbox.
+    bind::Setting{Vector{String}} = Default(String[])
     ## a list of CPUs to restrict the Julia process to (or empty if unconstrained).
     cpus::Setting{Vector{Int}} = Default(Int[])
     ## how many threads the Julia process should use

--- a/src/sandbox.jl
+++ b/src/sandbox.jl
@@ -286,6 +286,29 @@ function setup_generic_sandbox(config::Configuration, cmd::Cmd; workdir::String,
         end
     end
 
+    # additionally setup user-requested bind mounts
+    for spec in config.bind
+        parts = split(spec, ':')
+        if !(2 <= length(parts) <= 3)
+            # `--bind src:dst[:ro|:rw]`, default `rw`
+            error("invalid --bind spec `$spec`: expected `src:dst[:ro|:rw]`")
+        end
+
+        writable = true
+        source, destination = abspath(String(parts[1])), String(parts[2])
+        if length(parts) == 3
+            let mode = String(parts[3])
+                if !(mode in ("ro", "rw"))
+                    error("invalid --bind mode `$mode` in `$spec`: must be `ro` or `rw`")
+                end
+                writable = (mode == "rw")
+            end
+        end
+
+        isdir(source) || mkpath(source) # auto-create host path, if missing
+        push!(sandbox_mounts, destination => BindMount(; source, writable))
+    end
+
     env = merge(Dict(
         # some essential env vars (since we don't run from a shell)
         "PATH" => "/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin",


### PR DESCRIPTION
This is intended for "data collection" local PkgEval runs, where you need to be able to mount some persistent host directory to the sandbox to save results.