### PR TITLE
Don't select yanked versions as the version to test

### DIFF
--- a/src/registry.jl
+++ b/src/registry.jl
@@ -53,6 +53,21 @@ function get_pkgserver_registry(requested_uuid)
     return dir
 end
 
+# Determine the version of a package that we should test: the most recent one that has not
+# been yanked. Yanked versions cannot be resolved by Pkg, so selecting one would report the
+# package as uninstallable for as long as the yank stands. Returns `nothing` if every
+# registered version has been yanked, in which case the package cannot be tested at all.
+function latest_installable_version(version_info)
+    latest = nothing
+    for (version, info) in version_info
+        info.yanked && continue
+        if latest === nothing || version > latest
+            latest = version
+        end
+    end
+    return latest
+end
+
 """
     packages(config::Configuration)::Dict{String,Package}
 
@@ -105,7 +120,8 @@ function _get_packages(config::Configuration)
         # we could be smarter here and intersect the known versions of a package
         # with each Julia version, but that's a lot more complicated.
         info = Pkg.Registry.registry_info(pkg)
-        version = maximum(keys(info.version_info))
+        version = latest_installable_version(info.version_info)
+        version === nothing && continue
 
         # check if this package is compatible with the current Julia version
         compat = true
@@ -156,7 +172,8 @@ function package_dependencies(config; transitive=true)
     for (_, pkg) in registry_instance
         # we only consider the latest version of each package; see `get_packages`
         info = Pkg.Registry.registry_info(pkg)
-        version = maximum(keys(info.version_info))
+        version = latest_installable_version(info.version_info)
+        version === nothing && continue
 
         # iterate the dependencies
         pkg_deps = Set{String}()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using PkgEval
 using Test
 using Git
+using Pkg
 
 julia = get(ENV, "JULIA", "")
 if isempty(julia)
@@ -25,6 +26,23 @@ cgroup_controllers = PkgEval.get_cgroup_controllers()
     # RHEL derivatives
     # https://github.com/JuliaCI/PkgEval.jl/pull/287
     @test PkgEval.parse_kernel_version("4.18.0-553.60.1.el8_10.x86_64") == v"4.18.0"
+end
+
+@testset "Registry" begin
+    version_entry(version, yanked=false) =
+        VersionNumber(version) =>
+            Pkg.Registry.VersionInfo(Base.SHA1(zeros(UInt8, 20)), yanked)
+
+    @test PkgEval.latest_installable_version(
+        Dict(version_entry("1.0.0"), version_entry("2.0.0"))) == v"2.0.0"
+
+    # a yanked latest version must not shadow the newest installable one
+    @test PkgEval.latest_installable_version(
+        Dict(version_entry("1.0.0"), version_entry("1.1.0"),
+             version_entry("2.0.0", true))) == v"1.1.0"
+
+    @test PkgEval.latest_installable_version(
+        Dict(version_entry("1.0.0", true), version_entry("2.0.0", true))) === nothing
 end
 
 @testset "Configuration" begin


### PR DESCRIPTION
> [!NOTE]
> Please ignore this PR until it has been reviewed by @ChrisRackauckas.

### Problem

`_get_packages` and `package_dependencies` both pick the version to test with:

```julia
version = maximum(keys(info.version_info))
```

`info.version_info` includes yanked versions, and `Pkg.Registry.VersionInfo` carries a `.yanked` field that is never consulted (`grep -rn yank src/` currently returns nothing). Pkg will not resolve a yanked version, so whenever a package's *highest* registered version has been yanked, PkgEval requests exactly that version and the package is recorded as `uninstallable` on every single run.

Because a yank is normally used to retract a bad release, the superseding release is usually *lower* than the yanked one, so no subsequent registration lifts the package out of this state. It stays untestable indefinitely.

A live example — `OrdinaryDiffEqCore`, whose v5.0.0 was yanked on 2026-04-28 ([General#153927](https://github.com/JuliaRegistries/General/pull/153927)):

```
Installing OrdinaryDiffEqCore...
   Resolving package versions...
Installation failed after 6.02s
ERROR: LoadError: Unsatisfiable requirements detected for package OrdinaryDiffEqCore [bbf590c4]:
 ├─possible versions are: 1.0.0 - 4.7.1 or uninstalled
 └─restricted to versions 5.0.0 by an explicit requirement — no versions left
PkgEval skipped after 56.46s: package could not be installed
```

([full log](https://s3.amazonaws.com/julialang-reports/nanosoldier/pkgeval/by_date/2026-07/18/OrdinaryDiffEqCore.primary.log)) The package installs fine in normal use; only PkgEval's explicit version pin fails.

This has a second-order effect: since the package then fails >75% of runs, [`unreliable_packages`](https://github.com/JuliaCI/NanosoldierReports/blob/master/tools/pkgeval_analysis/main.jl) adds it to `pkgeval_packages.toml`, and `determine_blacklist` excludes it from PR-triggered PkgEval runs. `OrdinaryDiffEqCore` and `DiffEqDevTools` have both been silently blacklisted this way since April.

### Fix

Add `latest_installable_version`, which returns the highest non-yanked version, and use it at both call sites. Packages with no non-yanked version at all are skipped rather than erroring on `maximum` over an empty collection.

### Impact

Checked against a current General checkout — 12 packages are currently affected:

```
DiffEqDevTools, Elemental_jll, JSExpr, KeyedDistributions, Librsvg_jll, NLPModels,
OrdinaryDiffEqCore, Patchelf_jll, QRacahSymbols, SPIRV_Headers_jll, libNVVM_jll, libsodium_jll
```

Before/after for two of them:

```
OrdinaryDiffEqCore     before(max): 5.0.0    after(fix): 4.11.0
DiffEqDevTools         before(max): 4.0.0    after(fix): 3.1.3
```

### Testing

Added a `Registry` testset covering the normal case, the yanked-latest case, and the all-yanked case.

Locally on Julia 1.12.4:

```
Test Summary:               | Pass  Error  Total     Time
PkgEval using Julia v1.12.4 |   86      3     89  1m21.2s
  Misc quick tests          |    2             2     1.0s
  Registry                  |    3             3     0.1s
  Configuration             |   81            81     0.8s
  Sandbox                   |           1      1    20.9s
  julia installation        |           1      1    58.2s
```

The `Sandbox` and `julia installation` errors are pre-existing environment limitations (no cgroup controllers, cannot build Julia here), not regressions — unmodified master at 690012b2 gives the identical 3 errors with 83 passes. I was not able to exercise the sandbox-dependent paths locally; CI should cover those.