### PR TITLE
Fix downloading of Buildkite artifacts

### DIFF
--- a/src/buildkite.jl
+++ b/src/buildkite.jl
@@ -1,6 +1,5 @@
 using Dates
-import HTTP, JSON3
-import HTTP: download
+import Downloads, HTTP, JSON3
 using Base: UUID, SHA1
 
 const buildkite_api = "https://api.buildkite.com/v2"
@@ -51,7 +50,7 @@ end
 function download(ba::BuildkiteArtifact)
     path = joinpath(download_dir, bytes2hex(ba.hash.bytes))
     if !isfile(path)
-        HTTP.download(ba.url, path; headers=buildkite_headers(), update_period=Inf)
+        Downloads.download(ba.url, path; headers=buildkite_headers())
     end
     return path
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using PkgEval
 using Test
 using Git
+import Downloads, HTTP
 
 julia = get(ENV, "JULIA", "")
 if isempty(julia)
@@ -25,6 +26,40 @@ cgroup_controllers = PkgEval.get_cgroup_controllers()
     # RHEL derivatives
     # https://github.com/JuliaCI/PkgEval.jl/pull/287
     @test PkgEval.parse_kernel_version("4.18.0-553.60.1.el8_10.x86_64") == v"4.18.0"
+end
+
+@testset "Buildkite" begin
+    contents = "artifact contents"
+    server = HTTP.serve!("127.0.0.1", 8080; listenany=true) do request
+        if HTTP.header(request, "Authorization", "") == "Bearer valid-token"
+            HTTP.Response(200, contents)
+        else
+            HTTP.Response(401, "unauthorized")
+        end
+    end
+
+    try
+        url = "http://127.0.0.1:$(HTTP.port(server))/artifact.tar.gz"
+        artifact(sha1) = PkgEval.BuildkiteArtifact(
+            Dict("download_url" => url, "filename" => "artifact.tar.gz",
+                 "sha1sum" => sha1))
+        # downloads are cached by hash, so start from a clean slate
+        uncached(sha1) = (ba = artifact(sha1);
+                          rm(joinpath(PkgEval.download_dir, sha1); force=true);
+                          ba)
+
+        withenv("BUILDKITE_TOKEN" => "valid-token") do
+            path = PkgEval.download(uncached("0"^40))
+            @test read(path, String) == contents
+        end
+
+        # the token has to actually make it into the request
+        withenv("BUILDKITE_TOKEN" => "invalid-token") do
+            @test_throws Downloads.RequestError PkgEval.download(uncached("1"^40))
+        end
+    finally
+        close(server)
+    end
 end
 
 @testset "Configuration" begin


### PR DESCRIPTION
> [!NOTE]
> Please ignore this PR until it has been reviewed by @ChrisRackauckas.

### Problem

`src/buildkite.jl:54` fetches artifacts with:

```julia
HTTP.download(ba.url, path; headers=buildkite_headers(), update_period=Inf)
```

HTTP.jl 2.x no longer provides its own `download`. `HTTP.download` still resolves — but only to the `Base.download` binding that reaches HTTP's namespace via URIs. On the resolved HTTP v2.6.0:

```julia
julia> methods(HTTP.download)
download(uri::URIs.URI, args...)      @ URIs
download(url::AbstractString)         @ Base download.jl:20
download(url::AbstractString, path::AbstractString) @ Base download.jl:19
```

None of those accept `headers` or `update_period`, so every Buildkite artifact download throws:

```
MethodError: no method matching download(::String, ::String; headers::Vector{Pair{String, String}}, update_period::Float64)
Closest candidates are:
  download(::AbstractString, ::AbstractString) got unsupported keyword arguments "headers", "update_period"
   @ Base download.jl:19
```

This is how the `master~N` configurations obtain their Julia binaries, so it breaks them. The `Julia 1.10 - Running master~10` CI job has been failing on master since the HTTP 2.x bump — see [the run for current HEAD (690012b2)](https://github.com/JuliaCI/PkgEval.jl/actions/runs/28576712967), where the artifact is located successfully and then the download throws:

```
┌ Debug: Found a matching artifact for JuliaLang/julia#master~10: https://api.buildkite.com/...
julia installation: Error During Test at test/runtests.jl:75
  MethodError: no method matching download(::String, ::String; headers=..., update_period=...)
```

### Fix

Use `Downloads.download`, which accepts `headers` and is already used for the other downloads in PkgEval (`src/julia.jl:39,59`, `src/registry.jl:41`). It is silent by default, so the `update_period=Inf` that existed to suppress progress output is no longer needed.

Also drops the now-unused `import HTTP: download`. That import is what made the breakage silent in the first place: it bound `download` to `Base.download`, so the call kept resolving instead of erroring at load time.

### Testing

Added a `Buildkite` testset that serves the artifact from a local HTTP server requiring a bearer token, then downloads it through `PkgEval.download(::BuildkiteArtifact)`. It covers both that the download succeeds and that the token is actually transmitted.

Verified the test reproduces the bug — against unmodified master at 690012b2 it fails with precisely the CI error:

```
Buildkite: Error During Test
  MethodError: no method matching download(::String, ::String; headers::Vector{Pair{String, String}}, update_period::Float64)
    [1] download(ba::PkgEval.BuildkiteArtifact)
      @ PkgEval ~/PkgEval.jl/src/buildkite.jl:54
Test Summary: | Error  Total  Time
Buildkite     |     1      1  4.9s
```

and passes with this change. Full suite locally on Julia 1.12.4:

```
Test Summary:               | Pass  Error  Total     Time
PkgEval using Julia v1.12.4 |   85      3     88  1m07.1s
  Misc quick tests          |    2             2     1.1s
  Buildkite                 |    2             2     3.7s
  Configuration             |   81            81     0.8s
  Sandbox                   |           1      1    14.7s
  julia installation        |           1      1    46.7s
```

The `Sandbox` and `julia installation` errors are pre-existing environment limitations here (no cgroup controllers, cannot build Julia), identical on unmodified master.

### Note on CI

The `master~10` job reads `BUILDKITE_TOKEN` from repository secrets, which GitHub does not expose to fork PRs, so that job will fail with a 401 on this PR before it ever reaches the fixed code path. It needs a run from a branch in this repository to actually exercise the fix.

Independent of #312; that one touches `src/registry.jl`. Both add a testset immediately after `Misc quick tests`, so whichever merges second may need a trivial conflict resolution there.